### PR TITLE
chore: update appsettings for keycloak and storage

### DIFF
--- a/backend/src/controlmat.Api/appsettings.Development.json
+++ b/backend/src/controlmat.Api/appsettings.Development.json
@@ -1,13 +1,30 @@
 {
+  "Keycloak": {
+    "Authority": "http://localhost:8080/realms/sumisan-dev",
+    "Audience": "sumisan-api",
+    "RequireHttpsMetadata": false
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost,1434;Database=SUMISAN;User Id=sa;Password=Sumisan2024!;TrustServerCertificate=true;MultipleActiveResultSets=true;"
+  },
+  "FileStorage": {
+    "ImagePath": "C:\\Temp\\SumiSan\\Photos",
+    "MaxPhotosPerWash": 99,
+    "MaxFileSizeMB": 5,
+    "AllowedExtensions": [
+      "jpg",
+      "jpeg",
+      "png"
+    ]
+  },
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information",
+      "Microsoft.EntityFrameworkCore": "Information",
+      "Microsoft.AspNetCore.Authentication": "Debug",
+      "Controlmat": "Debug"
     }
-  },
-  "Jwt": {
-    "Issuer": "SumisanDev",
-    "Audience": "SumisanDev",
-    "Key": "DEV_ONLY_SECRET_32+CHARS_CHANGE_ME"
   }
 }
+

--- a/backend/src/controlmat.Api/appsettings.json
+++ b/backend/src/controlmat.Api/appsettings.json
@@ -1,13 +1,38 @@
 {
+  "Keycloak": {
+    "Authority": "https://your-keycloak-server/realms/sumisan",
+    "Audience": "sumisan-api",
+    "RequireHttpsMetadata": true
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:4200",
+      "https://localhost:4200",
+      "https://sumisan-frontend.example.com"
+    ]
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost,1434;Database=SUMISAN;User Id=sa;Password=Sumisan2024!;TrustServerCertificate=true;MultipleActiveResultSets=true;"
+  },
+  "FileStorage": {
+    "ImagePath": "C:\\SumiSan\\Photos",
+    "MaxPhotosPerWash": 99,
+    "MaxFileSizeMB": 5,
+    "AllowedExtensions": [
+      "jpg",
+      "jpeg",
+      "png"
+    ]
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Information",
+      "Microsoft.AspNetCore.Authentication": "Debug",
+      "Controlmat": "Debug"
     }
   },
-  "AllowedHosts": "*",
-  "Keycloak": {
-    "Authority": "http://localhost:8080/realms/sumisan",
-    "Audience": "sumisan-api"
-  }
+  "AllowedHosts": "*"
 }
+


### PR DESCRIPTION
## Summary
- expand appsettings to include Keycloak, storage, and logging settings
- add development config for local Keycloak and storage paths

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b40467c5c832db7b5b32a77b9c0cf