### PR TITLE
Add SumisanDbContext and infrastructure layer

### DIFF
--- a/backend/src/controlmat.Api/Program.cs
+++ b/backend/src/controlmat.Api/Program.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Http;
 using System.Linq;
 using controlmat.Application;
-using controlmat.Infrastructure;
+using Controlmat.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 
@@ -14,7 +14,7 @@ builder.Host.UseSerilog((ctx, lc) => lc
     .Enrich.WithEnvironmentUserName());
 
 builder.Services.AddApplication();
-builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddInfrastructureServices(builder.Configuration);
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();

--- a/backend/src/controlmat.Infrastructure/Persistence/SumisanDbContext.cs
+++ b/backend/src/controlmat.Infrastructure/Persistence/SumisanDbContext.cs
@@ -1,0 +1,179 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Controlmat.Domain.Entities;
+
+namespace Controlmat.Infrastructure.Persistence
+{
+    public class SumisanDbContext : DbContext
+    {
+        public SumisanDbContext(DbContextOptions<SumisanDbContext> options) : base(options) { }
+
+        public DbSet<User> Users => Set<User>();
+        public DbSet<Machine> Machines => Set<Machine>();
+        public DbSet<Washing> Washings => Set<Washing>();
+        public DbSet<Prot> Prots => Set<Prot>();
+        public DbSet<Photo> Photos => Set<Photo>();
+        public DbSet<Parameter> Parameters => Set<Parameter>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<User>(entity =>
+            {
+                entity.HasKey(e => e.UserId);
+                entity.Property(e => e.UserId).ValueGeneratedOnAdd();
+                entity.Property(e => e.UserName)
+                    .IsRequired()
+                    .HasMaxLength(100);
+                entity.Property(e => e.Role)
+                    .HasMaxLength(50);
+            });
+
+            modelBuilder.Entity<Machine>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).ValueGeneratedNever();
+                entity.Property(e => e.Name)
+                    .IsRequired()
+                    .HasMaxLength(50);
+            });
+
+            modelBuilder.Entity<Washing>(entity =>
+            {
+                entity.HasKey(e => e.WashingId);
+                entity.Property(e => e.WashingId).ValueGeneratedNever();
+
+                entity.Property(e => e.Status)
+                    .IsRequired()
+                    .HasColumnType("char(1)")
+                    .HasDefaultValue('P');
+
+                entity.Property(e => e.StartDate)
+                    .IsRequired()
+                    .HasColumnType("datetime");
+
+                entity.Property(e => e.EndDate)
+                    .HasColumnType("datetime");
+
+                entity.Property(e => e.StartObservation)
+                    .HasMaxLength(100);
+
+                entity.Property(e => e.FinishObservation)
+                    .HasMaxLength(100);
+
+                entity.HasOne(w => w.Machine)
+                    .WithMany(m => m.Washings)
+                    .HasForeignKey(w => w.MachineId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(w => w.StartUser)
+                    .WithMany(u => u.StartedWashes)
+                    .HasForeignKey(w => w.StartUserId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(w => w.EndUser)
+                    .WithMany(u => u.FinishedWashes)
+                    .HasForeignKey(w => w.EndUserId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasIndex(w => w.Status);
+                entity.HasIndex(w => w.MachineId);
+                entity.HasIndex(w => w.StartDate);
+            });
+
+            modelBuilder.Entity<Prot>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).ValueGeneratedOnAdd();
+
+                entity.Property(e => e.ProtId)
+                    .IsRequired()
+                    .HasMaxLength(7);
+
+                entity.Property(e => e.BatchNumber)
+                    .IsRequired()
+                    .HasMaxLength(4);
+
+                entity.Property(e => e.BagNumber)
+                    .IsRequired()
+                    .HasMaxLength(5);
+
+                entity.HasOne(p => p.Washing)
+                    .WithMany(w => w.Prots)
+                    .HasForeignKey(p => p.WashingId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasIndex(p => p.WashingId);
+            });
+
+            modelBuilder.Entity<Photo>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).ValueGeneratedOnAdd();
+
+                entity.Property(e => e.FileName)
+                    .IsRequired()
+                    .HasMaxLength(255);
+
+                entity.Property(e => e.FilePath)
+                    .IsRequired()
+                    .HasMaxLength(255);
+
+                entity.Property(e => e.CreatedAt)
+                    .IsRequired()
+                    .HasColumnType("datetime")
+                    .HasDefaultValueSql("GETUTCDATE()");
+
+                entity.HasOne(p => p.Washing)
+                    .WithMany(w => w.Photos)
+                    .HasForeignKey(p => p.WashingId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasIndex(p => p.WashingId);
+            });
+
+            modelBuilder.Entity<Parameter>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Id).ValueGeneratedOnAdd();
+
+                entity.Property(e => e.Name)
+                    .IsRequired()
+                    .HasMaxLength(50);
+
+                entity.Property(e => e.Value)
+                    .IsRequired()
+                    .HasMaxLength(255);
+
+                entity.HasIndex(p => p.Name).IsUnique();
+            });
+
+            SeedData(modelBuilder);
+        }
+
+        private void SeedData(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Parameter>().HasData(
+                new Parameter { Id = 1, Name = "ImagePath", Value = "C:\\SumiSan\\Photos" },
+                new Parameter { Id = 2, Name = "MaxPhotosPerWash", Value = "99" },
+                new Parameter { Id = 3, Name = "MaxFileSizeMB", Value = "5" },
+                new Parameter { Id = 4, Name = "AllowedExtensions", Value = "jpg,jpeg,png" }
+            );
+
+            modelBuilder.Entity<Machine>().HasData(
+                new Machine { Id = 1, Name = "Máquina 1" },
+                new Machine { Id = 2, Name = "Máquina 2" }
+            );
+
+            if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development")
+            {
+                modelBuilder.Entity<User>().HasData(
+                    new User { UserId = 1, UserName = "operario1", Role = "Operator" },
+                    new User { UserId = 2, UserName = "operario2", Role = "Operator" },
+                    new User { UserId = 3, UserName = "supervisor", Role = "Supervisor" }
+                );
+            }
+        }
+    }
+}

--- a/backend/src/controlmat.Infrastructure/Repositories/MachineRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/MachineRepository.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Controlmat.Domain.Entities;
+using Controlmat.Domain.Interfaces;
+using Controlmat.Infrastructure.Persistence;
+
+namespace Controlmat.Infrastructure.Repositories
+{
+    public class MachineRepository : IMachineRepository
+    {
+        private readonly SumisanDbContext _context;
+
+        public MachineRepository(SumisanDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<Machine?> GetByIdAsync(int machineId)
+        {
+            return await _context.Machines.FindAsync(machineId);
+        }
+
+        public async Task<IEnumerable<Machine>> GetAllAsync()
+        {
+            return await _context.Machines.ToListAsync();
+        }
+    }
+}

--- a/backend/src/controlmat.Infrastructure/Repositories/ParameterRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/ParameterRepository.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Controlmat.Domain.Entities;
+using Controlmat.Domain.Interfaces;
+using Controlmat.Infrastructure.Persistence;
+
+namespace Controlmat.Infrastructure.Repositories
+{
+    public class ParameterRepository : IParameterRepository
+    {
+        private readonly SumisanDbContext _context;
+
+        public ParameterRepository(SumisanDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<Parameter?> GetByNameAsync(string name)
+        {
+            return await _context.Parameters.FirstOrDefaultAsync(p => p.Name == name);
+        }
+
+        public async Task<string?> GetValueAsync(string name)
+        {
+            var parameter = await GetByNameAsync(name);
+            return parameter?.Value;
+        }
+    }
+}

--- a/backend/src/controlmat.Infrastructure/Repositories/PhotoRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/PhotoRepository.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Controlmat.Domain.Entities;
+using Controlmat.Domain.Interfaces;
+using Controlmat.Infrastructure.Persistence;
+
+namespace Controlmat.Infrastructure.Repositories
+{
+    public class PhotoRepository : IPhotoRepository
+    {
+        private readonly SumisanDbContext _context;
+
+        public PhotoRepository(SumisanDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<Photo>> GetByWashingIdAsync(long washingId)
+        {
+            return await _context.Photos
+                .Where(p => p.WashingId == washingId)
+                .ToListAsync();
+        }
+
+        public async Task<int> CountByWashingIdAsync(long washingId)
+        {
+            return await _context.Photos.CountAsync(p => p.WashingId == washingId);
+        }
+
+        public async Task AddAsync(Photo photo)
+        {
+            await _context.Photos.AddAsync(photo);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/backend/src/controlmat.Infrastructure/Repositories/ProtRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/ProtRepository.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Controlmat.Domain.Entities;
+using Controlmat.Domain.Interfaces;
+using Controlmat.Infrastructure.Persistence;
+
+namespace Controlmat.Infrastructure.Repositories
+{
+    public class ProtRepository : IProtRepository
+    {
+        private readonly SumisanDbContext _context;
+
+        public ProtRepository(SumisanDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<Prot>> GetByWashingIdAsync(long washingId)
+        {
+            return await _context.Prots
+                .Where(p => p.WashingId == washingId)
+                .ToListAsync();
+        }
+
+        public async Task AddAsync(Prot prot)
+        {
+            await _context.Prots.AddAsync(prot);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/backend/src/controlmat.Infrastructure/Repositories/UserRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/UserRepository.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Controlmat.Domain.Entities;
+using Controlmat.Domain.Interfaces;
+using Controlmat.Infrastructure.Persistence;
+
+namespace Controlmat.Infrastructure.Repositories
+{
+    public class UserRepository : IUserRepository
+    {
+        private readonly SumisanDbContext _context;
+
+        public UserRepository(SumisanDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<User?> GetByIdAsync(int userId)
+        {
+            return await _context.Users.FindAsync(userId);
+        }
+
+        public async Task<IEnumerable<User>> GetAllAsync()
+        {
+            return await _context.Users.ToListAsync();
+        }
+    }
+}

--- a/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Controlmat.Domain.Entities;
+using Controlmat.Domain.Interfaces;
+using Controlmat.Infrastructure.Persistence;
+
+namespace Controlmat.Infrastructure.Repositories
+{
+    public class WashingRepository : IWashingRepository
+    {
+        private readonly SumisanDbContext _context;
+
+        public WashingRepository(SumisanDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<Washing?> GetByIdAsync(long id)
+        {
+            return await _context.Washings.FindAsync(id);
+        }
+
+        public async Task<Washing?> GetByIdWithDetailsAsync(long id)
+        {
+            return await _context.Washings
+                .Include(w => w.Machine)
+                .Include(w => w.StartUser)
+                .Include(w => w.EndUser)
+                .Include(w => w.Prots)
+                .Include(w => w.Photos)
+                .FirstOrDefaultAsync(w => w.WashingId == id);
+        }
+
+        public async Task<IEnumerable<Washing>> GetActiveWashesAsync()
+        {
+            return await _context.Washings
+                .Where(w => w.Status != 'F')
+                .ToListAsync();
+        }
+
+        public async Task<int> CountActiveAsync()
+        {
+            return await _context.Washings.CountAsync(w => w.Status != 'F');
+        }
+
+        public async Task<bool> IsMachineInUseAsync(int machineId)
+        {
+            return await _context.Washings.AnyAsync(w => w.MachineId == machineId && w.Status != 'F');
+        }
+
+        public async Task<long?> GetMaxWashingIdByDateAsync(DateTime date)
+        {
+            return await _context.Washings
+                .Where(w => w.StartDate.Date == date.Date)
+                .Select(w => (long?)w.WashingId)
+                .MaxAsync();
+        }
+
+        public async Task AddAsync(Washing washing)
+        {
+            await _context.Washings.AddAsync(washing);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateAsync(Washing washing)
+        {
+            _context.Washings.Update(washing);
+            await _context.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SumisanDbContext with table configuration and seed data
- register repositories and DbContext in dependency injection
- implement EF Core repositories for domain interfaces
- update API to use new infrastructure service registration

## Testing
- `dotnet build backend/controlmat.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b4764e9b4832d9be0743778e31a77