### PR TITLE
fix: standardize Controlmat namespace and clean DTOs

### DIFF
--- a/backend/src/controlmat.Api/Controllers/WeatherForecastController.cs
+++ b/backend/src/controlmat.Api/Controllers/WeatherForecastController.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 
-namespace controlmat.Api.Controllers
+namespace Controlmat.Api.Controllers
 {
     [ApiController]
     [Route("[controller]")]

--- a/backend/src/controlmat.Api/Program.cs
+++ b/backend/src/controlmat.Api/Program.cs
@@ -2,7 +2,7 @@ using Serilog;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Http;
 using System.Linq;
-using controlmat.Application;
+using Controlmat.Application;
 using Controlmat.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;

--- a/backend/src/controlmat.Api/WeatherForecast.cs
+++ b/backend/src/controlmat.Api/WeatherForecast.cs
@@ -1,4 +1,4 @@
-namespace controlmat.Api
+namespace Controlmat.Api
 {
     public class WeatherForecast
     {

--- a/backend/src/controlmat.Application/Class1.cs
+++ b/backend/src/controlmat.Application/Class1.cs
@@ -1,4 +1,4 @@
-﻿namespace controlmat.Application
+﻿namespace Controlmat.Application
 {
     public class Class1
     {

--- a/backend/src/controlmat.Application/Common/Commands/Washing/UploadPhotoCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/Washing/UploadPhotoCommand.cs
@@ -2,11 +2,11 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
-using controlmat.Domain.Interfaces;
-using controlmat.Domain.Entities;
+using Controlmat.Domain.Interfaces;
+using Controlmat.Domain.Entities;
 using System.Security.Claims;
 
-namespace controlmat.Application.Common.Commands.Washing;
+namespace Controlmat.Application.Common.Commands.Washing;
 
 public static class UploadPhotoCommand
 {

--- a/backend/src/controlmat.Application/Common/Dto/ActiveWashDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/ActiveWashDto.cs
@@ -2,7 +2,7 @@
 using System;
 
 
-namespace controlmat.Application.Common.Dto;
+namespace Controlmat.Application.Common.Dto;
 
 public class ActiveWashDto
 {

--- a/backend/src/controlmat.Application/Common/Dto/AddProtDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/AddProtDto.cs
@@ -1,4 +1,4 @@
-namespace controlmat.Application.Common.Dto;
+namespace Controlmat.Application.Common.Dto;
 
 public class AddProtDto
 {

--- a/backend/src/controlmat.Application/Common/Dto/FinishWashDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/FinishWashDto.cs
@@ -1,4 +1,4 @@
-namespace controlmat.Application.Common.Dto;
+namespace Controlmat.Application.Common.Dto;
 
 public class FinishWashDto
 {

--- a/backend/src/controlmat.Application/Common/Dto/MachineDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/MachineDto.cs
@@ -1,8 +1,7 @@
-namespace controlmat.Application.Common.Dto;
+namespace Controlmat.Application.Common.Dto;
 
 public class MachineDto
 {
-    public short Id { get; set; }
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public bool IsAvailable { get; set; }

--- a/backend/src/controlmat.Application/Common/Dto/NewWashDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/NewWashDto.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace controlmat.Application.Common.Dto;
+namespace Controlmat.Application.Common.Dto;
 
 public class NewWashDto
 {

--- a/backend/src/controlmat.Application/Common/Dto/PhotoDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/PhotoDto.cs
@@ -2,7 +2,7 @@
 using System;
 
 
-namespace controlmat.Application.Common.Dto;
+namespace Controlmat.Application.Common.Dto;
 
 public class PhotoDto
 {

--- a/backend/src/controlmat.Application/Common/Dto/PhotoUploadDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/PhotoUploadDto.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Http;
 
-namespace controlmat.Application.Common.Dto;
+namespace Controlmat.Application.Common.Dto;
 
 public class PhotoUploadDto
 {

--- a/backend/src/controlmat.Application/Common/Dto/ProtDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/ProtDto.cs
@@ -1,4 +1,4 @@
-namespace controlmat.Application.Common.Dto;
+namespace Controlmat.Application.Common.Dto;
 
 public class ProtDto
 {

--- a/backend/src/controlmat.Application/Common/Dto/UserDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/UserDto.cs
@@ -1,4 +1,4 @@
-namespace controlmat.Application.Common.Dto;
+namespace Controlmat.Application.Common.Dto;
 
 public class UserDto
 {

--- a/backend/src/controlmat.Application/Common/Dto/WashingResponseDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/WashingResponseDto.cs
@@ -2,13 +2,11 @@
 using System;
 using System.Collections.Generic;
 
-namespace controlmat.Application.Common.Dto;
+namespace Controlmat.Application.Common.Dto;
 
 public class WashingResponseDto
 {
     public long WashingId { get; set; }
-
-    public string Status { get; set; } = string.Empty;
 
     public int MachineId { get; set; }
     public string MachineName { get; set; } = string.Empty;

--- a/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
+++ b/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
@@ -1,8 +1,8 @@
 using AutoMapper;
-using controlmat.Application.Common.Dto;
-using controlmat.Domain.Entities;
+using Controlmat.Application.Common.Dto;
+using Controlmat.Domain.Entities;
 
-namespace controlmat.Application.Common.Mappings;
+namespace Controlmat.Application.Common.Mappings;
 
 public class MappingProfile : Profile
 {

--- a/backend/src/controlmat.Application/Common/Queries/Machine/GetMachinesQuery.cs
+++ b/backend/src/controlmat.Application/Common/Queries/Machine/GetMachinesQuery.cs
@@ -1,10 +1,10 @@
 using AutoMapper;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using controlmat.Application.Common.Dto;
-using controlmat.Domain.Interfaces;
+using Controlmat.Application.Common.Dto;
+using Controlmat.Domain.Interfaces;
 
-namespace controlmat.Application.Common.Queries.Machine;
+namespace Controlmat.Application.Common.Queries.Machine;
 
 public static class GetMachinesQuery
 {

--- a/backend/src/controlmat.Application/Common/Queries/User/GetUsersQuery.cs
+++ b/backend/src/controlmat.Application/Common/Queries/User/GetUsersQuery.cs
@@ -1,10 +1,10 @@
 using AutoMapper;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using controlmat.Application.Common.Dto;
-using controlmat.Domain.Interfaces;
+using Controlmat.Application.Common.Dto;
+using Controlmat.Domain.Interfaces;
 
-namespace controlmat.Application.Common.Queries.User;
+namespace Controlmat.Application.Common.Queries.User;
 
 public static class GetUsersQuery
 {

--- a/backend/src/controlmat.Application/Common/Queries/Washing/GetActiveWashesQuery.cs
+++ b/backend/src/controlmat.Application/Common/Queries/Washing/GetActiveWashesQuery.cs
@@ -1,10 +1,10 @@
 using AutoMapper;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using controlmat.Application.Common.Dto;
-using controlmat.Domain.Interfaces;
+using Controlmat.Application.Common.Dto;
+using Controlmat.Domain.Interfaces;
 
-namespace controlmat.Application.Common.Queries.Washing;
+namespace Controlmat.Application.Common.Queries.Washing;
 
 public static class GetActiveWashesQuery
 {

--- a/backend/src/controlmat.Application/Common/Queries/Washing/GetWashByIdQuery.cs
+++ b/backend/src/controlmat.Application/Common/Queries/Washing/GetWashByIdQuery.cs
@@ -1,10 +1,10 @@
 using AutoMapper;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using controlmat.Application.Common.Dto;
-using controlmat.Domain.Interfaces;
+using Controlmat.Application.Common.Dto;
+using Controlmat.Domain.Interfaces;
 
-namespace controlmat.Application.Common.Queries.Washing;
+namespace Controlmat.Application.Common.Queries.Washing;
 
 public static class GetWashByIdQuery
 {

--- a/backend/src/controlmat.Application/Common/Validators/AddProtDtoValidator.cs
+++ b/backend/src/controlmat.Application/Common/Validators/AddProtDtoValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
-using controlmat.Application.Common.Dto;
+using Controlmat.Application.Common.Dto;
 
-namespace controlmat.Application.Common.Validators;
+namespace Controlmat.Application.Common.Validators;
 
 public class AddProtDtoValidator : AbstractValidator<AddProtDto>
 {

--- a/backend/src/controlmat.Application/Common/Validators/FinishWashDtoValidator.cs
+++ b/backend/src/controlmat.Application/Common/Validators/FinishWashDtoValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
-using controlmat.Application.Common.Dto;
+using Controlmat.Application.Common.Dto;
 
-namespace controlmat.Application.Common.Validators;
+namespace Controlmat.Application.Common.Validators;
 
 public class FinishWashDtoValidator : AbstractValidator<FinishWashDto>
 {

--- a/backend/src/controlmat.Application/Common/Validators/NewWashDtoValidator.cs
+++ b/backend/src/controlmat.Application/Common/Validators/NewWashDtoValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
-using controlmat.Application.Common.Dto;
+using Controlmat.Application.Common.Dto;
 
-namespace controlmat.Application.Common.Validators;
+namespace Controlmat.Application.Common.Validators;
 
 public class NewWashDtoValidator : AbstractValidator<NewWashDto>
 {

--- a/backend/src/controlmat.Application/Common/Validators/PhotoUploadDtoValidator.cs
+++ b/backend/src/controlmat.Application/Common/Validators/PhotoUploadDtoValidator.cs
@@ -1,8 +1,8 @@
 using System.Linq;
 using FluentValidation;
-using controlmat.Application.Common.Dto;
+using Controlmat.Application.Common.Dto;
 
-namespace controlmat.Application.Common.Validators;
+namespace Controlmat.Application.Common.Validators;
 
 public class PhotoUploadDtoValidator : AbstractValidator<PhotoUploadDto>
 {

--- a/backend/src/controlmat.Application/Common/Validators/ProtDtoValidator.cs
+++ b/backend/src/controlmat.Application/Common/Validators/ProtDtoValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
-using controlmat.Application.Common.Dto;
+using Controlmat.Application.Common.Dto;
 
-namespace controlmat.Application.Common.Validators;
+namespace Controlmat.Application.Common.Validators;
 
 public class ProtDtoValidator : AbstractValidator<ProtDto>
 {

--- a/backend/src/controlmat.Application/DependencyInjection.cs
+++ b/backend/src/controlmat.Application/DependencyInjection.cs
@@ -3,7 +3,7 @@ using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace controlmat.Application;
+namespace Controlmat.Application;
 
 public static class DependencyInjection
 {

--- a/backend/src/controlmat.Infrastructure/Class1.cs
+++ b/backend/src/controlmat.Infrastructure/Class1.cs
@@ -1,4 +1,4 @@
-﻿namespace controlmat.Infrastructure
+﻿namespace Controlmat.Infrastructure
 {
     public class Class1
     {

--- a/backend/src/controlmat.Infrastructure/Configurations/MachineConfiguration.cs
+++ b/backend/src/controlmat.Infrastructure/Configurations/MachineConfiguration.cs
@@ -2,7 +2,7 @@ using Controlmat.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace controlmat.Infrastructure.Configurations;
+namespace Controlmat.Infrastructure.Configurations;
 
 public class MachineConfiguration : IEntityTypeConfiguration<Machine>
 {

--- a/backend/src/controlmat.Infrastructure/Configurations/ParameterConfiguration.cs
+++ b/backend/src/controlmat.Infrastructure/Configurations/ParameterConfiguration.cs
@@ -2,7 +2,7 @@ using Controlmat.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace controlmat.Infrastructure.Configurations;
+namespace Controlmat.Infrastructure.Configurations;
 
 public class ParameterConfiguration : IEntityTypeConfiguration<Parameter>
 {

--- a/backend/src/controlmat.Infrastructure/Configurations/PhotoConfiguration.cs
+++ b/backend/src/controlmat.Infrastructure/Configurations/PhotoConfiguration.cs
@@ -2,7 +2,7 @@ using Controlmat.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace controlmat.Infrastructure.Configurations;
+namespace Controlmat.Infrastructure.Configurations;
 
 public class PhotoConfiguration : IEntityTypeConfiguration<Photo>
 {

--- a/backend/src/controlmat.Infrastructure/Configurations/ProtConfiguration.cs
+++ b/backend/src/controlmat.Infrastructure/Configurations/ProtConfiguration.cs
@@ -2,7 +2,7 @@ using Controlmat.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace controlmat.Infrastructure.Configurations;
+namespace Controlmat.Infrastructure.Configurations;
 
 public class ProtConfiguration : IEntityTypeConfiguration<Prot>
 {

--- a/backend/src/controlmat.Infrastructure/Configurations/UserConfiguration.cs
+++ b/backend/src/controlmat.Infrastructure/Configurations/UserConfiguration.cs
@@ -2,7 +2,7 @@ using Controlmat.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace controlmat.Infrastructure.Configurations;
+namespace Controlmat.Infrastructure.Configurations;
 
 public class UserConfiguration : IEntityTypeConfiguration<User>
 {

--- a/backend/src/controlmat.Infrastructure/Configurations/WashingConfiguration.cs
+++ b/backend/src/controlmat.Infrastructure/Configurations/WashingConfiguration.cs
@@ -2,7 +2,7 @@ using Controlmat.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace controlmat.Infrastructure.Configurations;
+namespace Controlmat.Infrastructure.Configurations;
 
 public class WashingConfiguration : IEntityTypeConfiguration<Washing>
 {

--- a/backend/src/controlmat.Infrastructure/Persistence/ControlmatDbContext.cs
+++ b/backend/src/controlmat.Infrastructure/Persistence/ControlmatDbContext.cs
@@ -1,8 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Controlmat.Domain.Entities;
-using controlmat.Infrastructure.Configurations;
+using Controlmat.Infrastructure.Configurations;
 
-namespace controlmat.Infrastructure.Persistence;
+namespace Controlmat.Infrastructure.Persistence;
 
 public class ControlmatDbContext : DbContext
 {


### PR DESCRIPTION
## Summary
- Rename all backend namespaces and using directives to `Controlmat` for consistent PascalCase usage
- Remove duplicate properties from `MachineDto` and `WashingResponseDto`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b4a2eaf7c832d800f53e082f04a83