### PR TITLE
Use char comparisons for washing status

### DIFF
--- a/backend/src/controlmat.Application/Common/Commands/Washing/UploadPhotoCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/Washing/UploadPhotoCommand.cs
@@ -75,7 +75,7 @@ public static class UploadPhotoCommand
                     throw new InvalidOperationException($"Washing with ID {washingId} not found");
                 }
 
-                if (washing.Status != "P")
+                if (washing.Status != 'P')
                 {
                     _logger.LogWarning("⚠️ {Function} [Thread:{ThreadId}] - WASHING NOT IN PROGRESS. WashingId: {WashingId}, Status: {Status}",
                         function, threadId, washingId, washing.Status);

--- a/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
+++ b/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
@@ -12,8 +12,8 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.MachineName, opt => opt.MapFrom(src => src.Machine.Name))
             .ForMember(dest => dest.StartUserName, opt => opt.MapFrom(src => src.StartUser.UserName))
             .ForMember(dest => dest.EndUserName, opt => opt.MapFrom(src => src.EndUser != null ? src.EndUser.UserName : null))
-            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status[0]))
-            .ForMember(dest => dest.StatusDescription, opt => opt.MapFrom(src => src.Status == "P" ? "En Progreso" : "Finalizado"));
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status))
+            .ForMember(dest => dest.StatusDescription, opt => opt.MapFrom(src => src.Status == 'P' ? "En Progreso" : "Finalizado"));
 
         CreateMap<Washing, ActiveWashDto>()
             .ForMember(dest => dest.MachineName, opt => opt.MapFrom(src => src.Machine.Name))


### PR DESCRIPTION
## Summary
- Map washing status using chars instead of strings and update status description mapping
- Compare washing status against `'P'` when uploading photos

## Testing
- `dotnet build controlmat.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b4c71f6f4832dab050452cfb146ac