### PR TITLE
Fix Washing namespace collision in StartWashCommand

### DIFF
--- a/backend/src/controlmat.Application/Common/Commands/Washing/StartWashCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/Washing/StartWashCommand.cs
@@ -6,6 +6,7 @@ using Controlmat.Domain.Entities;
 using Controlmat.Domain.Interfaces;
 using System.Linq;
 using System;
+using WashingEntity = Controlmat.Domain.Entities.Washing;
 
 namespace Controlmat.Application.Common.Commands.Washing;
 
@@ -32,7 +33,7 @@ public static class StartWashCommand
         public async Task<WashingResponseDto> Handle(Request request, CancellationToken cancellationToken)
         {
             var dto = request.Dto;
-            var washing = new Washing
+            var washing = new WashingEntity
             {
                 MachineId = dto.MachineId,
                 StartUserId = dto.StartUserId,


### PR DESCRIPTION
## Summary
- Alias domain entity to resolve `Washing` namespace/type collision in StartWashCommand

## Testing
- `dotnet build` *(fails: command not found)*
- Attempted to install .NET SDK via `wget` *(network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689b4eff25a0832da201849bd568ba6c