### PR TITLE
Add missing DI registrations for Controlmat backend

### DIFF
--- a/backend/src/controlmat.Api/Program.cs
+++ b/backend/src/controlmat.Api/Program.cs
@@ -2,6 +2,9 @@ using Serilog;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Http;
 using System.Linq;
+using AutoMapper;
+using MediatR;
+using FluentValidation;
 using Controlmat.Application;
 using Controlmat.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -13,7 +16,15 @@ builder.Host.UseSerilog((ctx, lc) => lc
     .WriteTo.Console()
     .Enrich.WithEnvironmentUserName());
 
-builder.Services.AddApplication();
+// Dependency registrations
+builder.Services.AddAutoMapper(typeof(Controlmat.Application.Common.Mappings.MappingProfile));
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddMediatR(cfg =>
+{
+    cfg.RegisterServicesFromAssembly(typeof(Controlmat.Application.Common.Commands.Washing.StartWashCommand).Assembly);
+});
+builder.Services.AddValidatorsFromAssemblyContaining<Controlmat.Application.Common.Validators.NewWashDtoValidator>();
+builder.Services.AddApplicationServices();
 builder.Services.AddInfrastructureServices(builder.Configuration);
 
 builder.Services.AddControllers();

--- a/backend/src/controlmat.Application/DependencyInjection.cs
+++ b/backend/src/controlmat.Application/DependencyInjection.cs
@@ -7,7 +7,7 @@ namespace Controlmat.Application;
 
 public static class DependencyInjection
 {
-    public static IServiceCollection AddApplication(this IServiceCollection services)
+    public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
         services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());


### PR DESCRIPTION
## Summary
- register AutoMapper, HttpContextAccessor, MediatR, and FluentValidation in `Program.cs`
- expose `AddApplicationServices` extension method for application layer

## Testing
- `dotnet build controlmat.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed/403)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689b4f77e37c832d818070ab310af5ff