### PR TITLE
Add logging to StartWashCommand

### DIFF
--- a/backend/src/controlmat.Application/Common/Commands/Washing/StartWashCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/Washing/StartWashCommand.cs
@@ -32,25 +32,36 @@ public static class StartWashCommand
 
         public async Task<WashingResponseDto> Handle(Request request, CancellationToken cancellationToken)
         {
-            var dto = request.Dto;
-            var washing = new WashingEntity
+            try
             {
-                MachineId = dto.MachineId,
-                StartUserId = dto.StartUserId,
-                StartDate = DateTime.UtcNow,
-                Status = 'P',
-                StartObservation = dto.StartObservation,
-                Prots = dto.ProtEntries.Select(p => new Prot
+                var dto = request.Dto;
+                _logger.LogInformation("Starting wash: MachineId={MachineId}, StartUserId={StartUserId}", dto.MachineId, dto.StartUserId);
+
+                var washing = new WashingEntity
                 {
-                    ProtId = p.ProtId,
-                    BatchNumber = p.BatchNumber,
-                    BagNumber = p.BagNumber
-                }).ToList()
-            };
+                    MachineId = dto.MachineId,
+                    StartUserId = dto.StartUserId,
+                    StartDate = DateTime.UtcNow,
+                    Status = 'P',
+                    StartObservation = dto.StartObservation,
+                    Prots = dto.ProtEntries.Select(p => new Prot
+                    {
+                        ProtId = p.ProtId,
+                        BatchNumber = p.BatchNumber,
+                        BagNumber = p.BagNumber
+                    }).ToList()
+                };
 
-            await _washingRepo.AddAsync(washing);
+                await _washingRepo.AddAsync(washing);
+                _logger.LogInformation("Wash {WashingId} started successfully", washing.WashingId);
 
-            return _mapper.Map<WashingResponseDto>(washing);
+                return _mapper.Map<WashingResponseDto>(washing);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error starting wash");
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- log start and completion of washing operations
- handle and log exceptions in StartWashCommand

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c372a0ea4832d98d978ddabe03dc2