### PR TITLE
Add Serilog file logging with rolling files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ Thumbs.db
 
 # Logs
 logs/
+Logs/
+**/Logs/
 *.log
 
 # Environment files

--- a/backend/src/controlmat.Api/Program.cs
+++ b/backend/src/controlmat.Api/Program.cs
@@ -2,6 +2,7 @@ using Serilog;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Http;
 using System.Linq;
+using System.IO;
 using AutoMapper;
 using MediatR;
 using FluentValidation;
@@ -12,8 +13,12 @@ using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Ensure the log directory exists
+Directory.CreateDirectory("Logs");
+
 builder.Host.UseSerilog((ctx, lc) => lc
     .WriteTo.Console()
+    .WriteTo.File("Logs/controlmat-.log", rollingInterval: RollingInterval.Day)
     .Enrich.WithEnvironmentUserName());
 
 // Dependency registrations


### PR DESCRIPTION
## Summary
- add a Serilog file sink that writes daily rolling logs under `Logs/`
- create the `Logs` directory on startup and ignore it in git

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*


------
https://chatgpt.com/codex/tasks/task_e_689c3726c974832d9da5aa518a5a8913