### PR TITLE
Fix DTO validation for machine and prot entries

### DIFF
--- a/backend/src/controlmat.Application/Common/Dto/NewWashDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/NewWashDto.cs
@@ -1,11 +1,18 @@
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Controlmat.Application.Common.Dto;
 
 public class NewWashDto
 {
-    public int MachineId { get; set; }
-    public int StartUserId { get; set; }
+    [Required]
+    [Range(1, 4)]
+    public short MachineId { get; set; } = 1;
+
+    [Required]
+    [Range(1, int.MaxValue)]
+    public int StartUserId { get; set; } = 1;
+
     public string? StartObservation { get; set; }
     public List<ProtDto> ProtEntries { get; set; } = new();
 }

--- a/backend/src/controlmat.Application/Common/Dto/ProtDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/ProtDto.cs
@@ -1,10 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Controlmat.Application.Common.Dto;
 
 public class ProtDto
 {
-
-    public int Id { get; set; }
+    [Required]
     public string ProtId { get; set; } = string.Empty;
+
+    [Required]
     public string BatchNumber { get; set; } = string.Empty;
+
+    [Required]
     public string BagNumber { get; set; } = string.Empty;
 }

--- a/backend/src/controlmat.Application/Common/Validators/NewWashDtoValidator.cs
+++ b/backend/src/controlmat.Application/Common/Validators/NewWashDtoValidator.cs
@@ -9,7 +9,9 @@ public class NewWashDtoValidator : AbstractValidator<NewWashDto>
     {
         RuleFor(x => x.MachineId)
             .NotEmpty().WithMessage("MachineId is required")
-            .InclusiveBetween(1, 2).WithMessage("MachineId must be 1 or 2");
+            .GreaterThan((short)0)
+            .LessThanOrEqualTo((short)4)
+            .WithMessage("MachineId must be between 1 and 4");
 
         RuleFor(x => x.StartUserId)
             .NotEmpty().WithMessage("StartUserId is required")


### PR DESCRIPTION
## Summary
- enforce `MachineId` range and provide defaults for swagger
- remove internal `Id` from `ProtDto`
- tighten wash start validation for machine ids

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403; cannot install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689c39e7b32c832d8fae7fc7e6da8ff6