### PR TITLE
Use short machine identifiers and drop user role fields

### DIFF
--- a/agent_AI/v1_sin_gestraf/wash-management-agent-spec.txt
+++ b/agent_AI/v1_sin_gestraf/wash-management-agent-spec.txt
@@ -3,11 +3,11 @@ Entity Framework Core Models
 To fulfill the functional specification, we define the following EF Core entity models (with code-first approach for migrations
 learn.microsoft.com
 ):
-User – Represents a warehouse user who can start/finish washes. Fields: UserId (int primary key), UserName (string), Role.
+User – Represents a warehouse user who can start/finish washes. Fields: UserId (int primary key), UserName (string).
 Machine – Washing machine identifier. Fields: Id (smallint PK) and Name (string up to 50 chars). There are two machines (Machine 1 and 2), and at most one active wash per machine is allowed at a time (enforcing max two concurrent washes total).
 Washing – Represents a wash process record. Key fields:
 WashingId (long/string) – a unique ID in the format YYMMDDXX (date + two-digit sequence). This can be generated when a new wash is started.
-Machine (int) – Machine number (1 or 2) used for the wash.
+Machine (short) – Machine number (1 or 2) used for the wash.
 StartDate/EndDate (DateTime) – Timestamps for when the wash was started and finished.
 StartUserId/EndUserId (int) – References to the User who started and who finished the wash.
 Status (char) – Status of the wash: 'P' for In Progress or 'F' for Finished.
@@ -26,7 +26,7 @@ medium.com
 medium.com
 . Key DTOs include:
 NewWashDTO – used when starting a new wash. Contains necessary info to initiate a wash:
-MachineId (int) – which machine to use.
+MachineId (short) – which machine to use.
 StartUserId (int) – the user starting the wash.
 ProtEntries – a list of prot items (each with ProtId, BatchNumber, BagNumber) to be included in this wash.
 StartObservation (string, optional) – any starting observations.

--- a/agent_AI/wash-management-agent-spec.txt
+++ b/agent_AI/wash-management-agent-spec.txt
@@ -19,7 +19,7 @@ controlmat/
 
 ## 📌 Domain Models (controlmat.Domain.Entities)
 
-* `User`: UserId, UserName, Role (local user records for business operations)
+* `User`: UserId, UserName (local user records for business operations)
 * `Machine`: Id, Name
 * `Washing`: WashingId (YYMMDDXX), MachineId, Start/End Timestamps, UserIds, Status ('P' or 'F'), Observations
 * `Prot`: WashingId FK, ProtId, BatchNumber, BagNumber

--- a/agent_AI/wash.architecture.txt
+++ b/agent_AI/wash.architecture.txt
@@ -104,7 +104,7 @@ public interface IWashingRepository
 {
     Task AddAsync(Washing wash);
     Task<int> CountActiveAsync();
-    Task<bool> IsMachineInUseAsync(int machineId);
+    Task<bool> IsMachineInUseAsync(short machineId);
     Task<Washing?> GetByIdAsync(long id);
 }
 ```

--- a/agent_AI/wash_dtos_spec.cs
+++ b/agent_AI/wash_dtos_spec.cs
@@ -12,7 +12,7 @@ namespace Controlmat.Application.Common.Dto
     // Sent when starting a new wash cycle. Contains machine, operator, optional observations, and at least one Prot entry.
     public class NewWashDto
     {
-        public int MachineId { get; set; }                    // Must be 1 or 2
+        public short MachineId { get; set; }                   // Must be 1 or 2
         public int StartUserId { get; set; }                  // Operator initiating the wash
         public string? StartObservation { get; set; }         // Optional field for initial notes
         public List<ProtDto> ProtEntries { get; set; } = new(); // Required: at least one Prot
@@ -68,7 +68,7 @@ namespace Controlmat.Application.Common.Dto
     public class WashingResponseDto
     {
         public long WashingId { get; set; }
-        public int MachineId { get; set; }
+        public short MachineId { get; set; }
         public int StartUserId { get; set; }
         public int? EndUserId { get; set; }                     // Nullable until wash is finalized
         public DateTime StartDate { get; set; }
@@ -87,14 +87,13 @@ namespace Controlmat.Application.Common.Dto
     {
         public int UserId { get; set; }
         public string UserName { get; set; } = string.Empty;
-        public string? Role { get; set; }
     }
 
     // 🏭 MachineDto  
     // Machine representation for dropdowns and availability checking
     public class MachineDto
     {
-        public int Id { get; set; }
+        public short Id { get; set; }
         public string Name { get; set; } = string.Empty;
         public bool IsAvailable { get; set; } = true;           // Calculated based on active washes
     }

--- a/backend/src/controlmat.Application/Common/Dto/ActiveWashDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/ActiveWashDto.cs
@@ -7,7 +7,7 @@ namespace Controlmat.Application.Common.Dto;
 public class ActiveWashDto
 {
     public long WashingId { get; set; }
-    public int MachineId { get; set; }
+    public short MachineId { get; set; }
     public string MachineName { get; set; } = string.Empty;
     public DateTime StartDate { get; set; }
     public string StartUserName { get; set; } = string.Empty;

--- a/backend/src/controlmat.Application/Common/Dto/MachineDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/MachineDto.cs
@@ -2,7 +2,7 @@ namespace Controlmat.Application.Common.Dto;
 
 public class MachineDto
 {
-    public int Id { get; set; }
+    public short Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public bool IsAvailable { get; set; }
 }

--- a/backend/src/controlmat.Application/Common/Dto/WashingResponseDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/WashingResponseDto.cs
@@ -8,7 +8,7 @@ public class WashingResponseDto
 {
     public long WashingId { get; set; }
 
-    public int MachineId { get; set; }
+    public short MachineId { get; set; }
     public string MachineName { get; set; } = string.Empty;
     public int StartUserId { get; set; }
     public string StartUserName { get; set; } = string.Empty;

--- a/backend/src/controlmat.Domain/Entities/Machine.cs
+++ b/backend/src/controlmat.Domain/Entities/Machine.cs
@@ -4,7 +4,7 @@ namespace Controlmat.Domain.Entities;
 
 public class Machine
 {
-    public int Id { get; set; }
+    public short Id { get; set; }
     public string Name { get; set; } = string.Empty;
 
     public ICollection<Washing> Washings { get; set; } = new List<Washing>();

--- a/backend/src/controlmat.Domain/Entities/Washing.cs
+++ b/backend/src/controlmat.Domain/Entities/Washing.cs
@@ -6,7 +6,7 @@ namespace Controlmat.Domain.Entities;
 public class Washing
 {
     public long WashingId { get; set; }
-    public int MachineId { get; set; }
+    public short MachineId { get; set; }
     public int StartUserId { get; set; }
     public int? EndUserId { get; set; }
     public DateTime StartDate { get; set; }

--- a/backend/src/controlmat.Domain/Interfaces/IMachineRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IMachineRepository.cs
@@ -7,7 +7,7 @@ namespace Controlmat.Domain.Interfaces;
 
 public interface IMachineRepository
 {
-    Task<Machine?> GetByIdAsync(int machineId);
+    Task<Machine?> GetByIdAsync(short machineId);
     Task<IEnumerable<Machine>> GetAllAsync();
 
 }

--- a/backend/src/controlmat.Domain/Interfaces/IWashingRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IWashingRepository.cs
@@ -13,7 +13,7 @@ public interface IWashingRepository
     Task<Washing?> GetByIdWithDetailsAsync(long id);
     Task<IEnumerable<Washing>> GetActiveWashesAsync();
     Task<int> CountActiveAsync();
-    Task<bool> IsMachineInUseAsync(int machineId);
+    Task<bool> IsMachineInUseAsync(short machineId);
     Task<long?> GetMaxWashingIdByDateAsync(DateTime date);
     Task AddAsync(Washing washing);
     Task UpdateAsync(Washing washing);

--- a/backend/src/controlmat.Infrastructure/Persistence/SumisanDbContext.cs
+++ b/backend/src/controlmat.Infrastructure/Persistence/SumisanDbContext.cs
@@ -160,8 +160,8 @@ namespace Controlmat.Infrastructure.Persistence
             );
 
             modelBuilder.Entity<Machine>().HasData(
-                new Machine { Id = 1, Name = "Máquina 1" },
-                new Machine { Id = 2, Name = "Máquina 2" }
+                new Machine { Id = (short)1, Name = "Máquina 1" },
+                new Machine { Id = (short)2, Name = "Máquina 2" }
             );
 
             if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development")

--- a/backend/src/controlmat.Infrastructure/Repositories/MachineRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/MachineRepository.cs
@@ -16,7 +16,7 @@ namespace Controlmat.Infrastructure.Repositories
             _context = context;
         }
 
-        public async Task<Machine?> GetByIdAsync(int machineId)
+        public async Task<Machine?> GetByIdAsync(short machineId)
         {
             return await _context.Machines.FindAsync(machineId);
         }

--- a/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
@@ -46,7 +46,7 @@ namespace Controlmat.Infrastructure.Repositories
             return await _context.Washings.CountAsync(w => w.Status != 'F');
         }
 
-        public async Task<bool> IsMachineInUseAsync(int machineId)
+        public async Task<bool> IsMachineInUseAsync(short machineId)
         {
             return await _context.Washings.AnyAsync(w => w.MachineId == machineId && w.Status != 'F');
         }


### PR DESCRIPTION
## Summary
- Switch machine identifiers and MachineId properties from `int` to `short` across DTOs, entities, and repository interfaces
- Remove obsolete Role fields from user DTO specs
- Seed machines using `short` identifiers

## Testing
- `dotnet build controlmat.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c3bc2716c832da4d78a48030f9113