### PR TITLE
Use short identifiers for machine queries

### DIFF
--- a/backend/src/controlmat.Application/Common/Queries/Machine/GetMachinesQuery.cs
+++ b/backend/src/controlmat.Application/Common/Queries/Machine/GetMachinesQuery.cs
@@ -43,7 +43,7 @@ public static class GetMachinesQuery
 
                 foreach (var machine in result)
                 {
-                    machine.IsAvailable = !await _washingRepo.IsMachineInUseAsync(machine.Id);
+                    machine.IsAvailable = !await _washingRepo.IsMachineInUseAsync((short)machine.Id);
                 }
 
                 _logger.LogInformation("✅ {Function} [Thread:{ThreadId}] - COMPLETED. MachineCount: {Count}",

--- a/backend/src/controlmat.Domain/Interfaces/IMachineRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IMachineRepository.cs
@@ -7,7 +7,7 @@ namespace Controlmat.Domain.Interfaces;
 
 public interface IMachineRepository
 {
-    Task<Machine?> GetByIdAsync(int machineId);
+    Task<Machine?> GetByIdAsync(short machineId);
     Task<IEnumerable<Machine>> GetAllAsync();
 
 }

--- a/backend/src/controlmat.Domain/Interfaces/IWashingRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IWashingRepository.cs
@@ -13,7 +13,7 @@ public interface IWashingRepository
     Task<Washing?> GetByIdWithDetailsAsync(long id);
     Task<IEnumerable<Washing>> GetActiveWashesAsync();
     Task<int> CountActiveAsync();
-    Task<bool> IsMachineInUseAsync(int machineId);
+    Task<bool> IsMachineInUseAsync(short machineId);
     Task<long?> GetMaxWashingIdByDateAsync(DateTime date);
     Task AddAsync(Washing washing);
     Task UpdateAsync(Washing washing);

--- a/backend/src/controlmat.Infrastructure/Repositories/MachineRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/MachineRepository.cs
@@ -16,7 +16,7 @@ namespace Controlmat.Infrastructure.Repositories
             _context = context;
         }
 
-        public async Task<Machine?> GetByIdAsync(int machineId)
+        public async Task<Machine?> GetByIdAsync(short machineId)
         {
             return await _context.Machines.FindAsync(machineId);
         }

--- a/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
@@ -46,7 +46,7 @@ namespace Controlmat.Infrastructure.Repositories
             return await _context.Washings.CountAsync(w => w.Status != 'F');
         }
 
-        public async Task<bool> IsMachineInUseAsync(int machineId)
+        public async Task<bool> IsMachineInUseAsync(short machineId)
         {
             return await _context.Washings.AnyAsync(w => w.MachineId == machineId && w.Status != 'F');
         }


### PR DESCRIPTION
## Summary
- use `short` for machine id lookups
- accept `short` in washing repository when checking machine usage

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c3bc652a8832dad47e458330edab2