### PR TITLE
Configure smallint mappings for machine identifiers

### DIFF
--- a/backend/src/controlmat.Infrastructure/Persistence/SumisanDbContext.cs
+++ b/backend/src/controlmat.Infrastructure/Persistence/SumisanDbContext.cs
@@ -31,7 +31,9 @@ namespace Controlmat.Infrastructure.Persistence
             modelBuilder.Entity<Machine>(entity =>
             {
                 entity.HasKey(e => e.Id);
-                entity.Property(e => e.Id).ValueGeneratedNever();
+                entity.Property(e => e.Id)
+                    .ValueGeneratedNever()
+                    .HasColumnType("smallint");
                 entity.Property(e => e.Name)
                     .IsRequired()
                     .HasMaxLength(50);
@@ -41,6 +43,9 @@ namespace Controlmat.Infrastructure.Persistence
             {
                 entity.HasKey(e => e.WashingId);
                 entity.Property(e => e.WashingId).ValueGeneratedNever();
+
+                entity.Property(e => e.MachineId)
+                    .HasColumnType("smallint");
 
                 entity.Property(e => e.Status)
                     .IsRequired()


### PR DESCRIPTION
## Summary
- Map `Machine.Id` as `smallint` and ensure `Washing.MachineId` uses the same type
- Confirm no stale `Role` mapping for `User` entity in `SumisanDbContext`

## Testing
- `dotnet build` *(fails: dotnet: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c3bd2055c832da967014e90d906ec