### PR TITLE
Use short range for MachineId validation

### DIFF
--- a/backend/src/controlmat.Application/Common/Validators/NewWashDtoValidator.cs
+++ b/backend/src/controlmat.Application/Common/Validators/NewWashDtoValidator.cs
@@ -9,8 +9,7 @@ public class NewWashDtoValidator : AbstractValidator<NewWashDto>
     {
         RuleFor(x => x.MachineId)
             .NotEmpty().WithMessage("MachineId is required")
-            .GreaterThan((short)0)
-            .LessThanOrEqualTo((short)4)
+            .InclusiveBetween((short)1, (short)4)
             .WithMessage("MachineId must be between 1 and 4");
 
         RuleFor(x => x.StartUserId)


### PR DESCRIPTION
## Summary
- Replace MachineId validation with `InclusiveBetween` using `short` bounds to align with DTO type
- Confirm no validators referenced removed `Role` property

## Testing
- `dotnet build controlmat.sln` *(fails: dotnet not installed)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c3bcb5298832d92aa709c5010b480