### PR TITLE
feat: add Lavado DTO and endpoint

### DIFF
--- a/backend/src/controlmat.Api/Controllers/WashingController.cs
+++ b/backend/src/controlmat.Api/Controllers/WashingController.cs
@@ -43,7 +43,7 @@ namespace Controlmat.Api.Controllers
         [ProducesResponseType(typeof(ProblemDetails), 409)]
         public async Task<IActionResult> StartWash([FromBody] NewWashDto dto)
         {
-            _logger.LogInformation("📝 POST /api/washing - Starting new wash for MachineId: {MachineId}, StartUserId: {StartUserId}, ProtCount: {ProtCount}", 
+            _logger.LogInformation("📝 POST /api/washing - Starting new wash for MachineId: {MachineId}, StartUserId: {StartUserId}, ProtCount: {ProtCount}",
                 dto.MachineId, dto.StartUserId, dto.ProtEntries?.Count ?? 0);
 
             try
@@ -61,6 +61,25 @@ namespace Controlmat.Api.Controllers
                     Status = 409
                 });
             }
+        }
+
+        [HttpPost("lavado")]
+        [ProducesResponseType(typeof(WashingResponseDto), 200)]
+        public async Task<IActionResult> StartLavado([FromBody] LavadoDto lavado)
+        {
+            _logger.LogInformation("📝 POST /api/washing/lavado - MachineId: {MachineId}, StartUserId: {StartUserId}, ProtCount: {ProtCount}",
+                lavado.MachineId, lavado.StartUserId, lavado.Prots?.Count ?? 0);
+
+            var newWashDto = new NewWashDto
+            {
+                MachineId = lavado.MachineId,
+                StartUserId = lavado.StartUserId,
+                StartObservation = lavado.StartObservation,
+                ProtEntries = lavado.Prots
+            };
+
+            var result = await _mediator.Send(new StartWashCommand.Request { Dto = newWashDto });
+            return Ok(result);
         }
 
         /// <summary>

--- a/backend/src/controlmat.Application/Common/Dto/LavadoDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/LavadoDto.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace Controlmat.Application.Common.Dto;
+
+public class LavadoDto
+{
+    public long? WashingId { get; set; }
+    public short MachineId { get; set; }
+    public int StartUserId { get; set; }
+    public int? EndUserId { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public string Status { get; set; } = "P";
+    public string? StartObservation { get; set; }
+    public string? FinishObservation { get; set; }
+    public List<ProtDto> Prots { get; set; } = new();
+    public List<string> Photos { get; set; } = new();
+}

--- a/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
+++ b/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using Controlmat.Application.Common.Dto;
 using Controlmat.Domain.Entities;
+using System.Linq;
 
 namespace Controlmat.Application.Common.Mappings;
 
@@ -32,5 +33,12 @@ public class MappingProfile : Profile
 
         CreateMap<Machine, MachineDto>()
             .ForMember(dest => dest.IsAvailable, opt => opt.Ignore());
+
+        CreateMap<Washing, LavadoDto>()
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status.ToString()))
+            .ForMember(dest => dest.Photos, opt => opt.MapFrom(src => src.Photos.Select(p => p.FileName)));
+
+        CreateMap<LavadoDto, NewWashDto>()
+            .ForMember(dest => dest.ProtEntries, opt => opt.MapFrom(src => src.Prots));
     }
 }


### PR DESCRIPTION
## Summary
- add LavadoDto to mirror frontend expectations
- map LavadoDto with Washing and NewWashDto
- expose POST /api/washing/lavado endpoint for compatibility

## Testing
- `dotnet build backend/controlmat.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c51bd098c832d87aa3efbaad4e279