### PR TITLE
Rename Washing commands namespace to WashCycle

### DIFF
--- a/backend/src/controlmat.Api/Controllers/WashingController.cs
+++ b/backend/src/controlmat.Api/Controllers/WashingController.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using MediatR;
-using Controlmat.Application.Common.Commands.Washing;
+using Controlmat.Application.Common.Commands.WashCycle;
 using Controlmat.Application.Common.Queries.Washing;
 using Controlmat.Application.Common.Queries.User;
 using Controlmat.Application.Common.Queries.Machine;

--- a/backend/src/controlmat.Api/Program.cs
+++ b/backend/src/controlmat.Api/Program.cs
@@ -26,7 +26,7 @@ builder.Services.AddAutoMapper(typeof(Controlmat.Application.Common.Mappings.Map
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddMediatR(cfg =>
 {
-    cfg.RegisterServicesFromAssembly(typeof(Controlmat.Application.Common.Commands.Washing.StartWashCommand).Assembly);
+    cfg.RegisterServicesFromAssembly(typeof(Controlmat.Application.Common.Commands.WashCycle.StartWashCommand).Assembly);
 });
 builder.Services.AddValidatorsFromAssemblyContaining<Controlmat.Application.Common.Validators.NewWashDtoValidator>();
 builder.Services.AddApplicationServices();

--- a/backend/src/controlmat.Application/Common/Commands/WashCycle/AddProtCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/WashCycle/AddProtCommand.cs
@@ -5,7 +5,7 @@ using Controlmat.Domain.Entities;
 using Controlmat.Domain.Interfaces;
 using System;
 
-namespace Controlmat.Application.Common.Commands.Washing;
+namespace Controlmat.Application.Common.Commands.WashCycle;
 
 public static class AddProtCommand
 {

--- a/backend/src/controlmat.Application/Common/Commands/WashCycle/FinishWashCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/WashCycle/FinishWashCommand.cs
@@ -5,7 +5,7 @@ using Controlmat.Application.Common.Dto;
 using Controlmat.Domain.Interfaces;
 using System;
 
-namespace Controlmat.Application.Common.Commands.Washing;
+namespace Controlmat.Application.Common.Commands.WashCycle;
 
 public static class FinishWashCommand
 {

--- a/backend/src/controlmat.Application/Common/Commands/WashCycle/StartWashCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/WashCycle/StartWashCommand.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System;
 using WashingEntity = Controlmat.Domain.Entities.Washing;
 
-namespace Controlmat.Application.Common.Commands.Washing;
+namespace Controlmat.Application.Common.Commands.WashCycle;
 
 public static class StartWashCommand
 {

--- a/backend/src/controlmat.Application/Common/Commands/WashCycle/UploadPhotoCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/WashCycle/UploadPhotoCommand.cs
@@ -6,7 +6,7 @@ using Controlmat.Domain.Interfaces;
 using Controlmat.Domain.Entities;
 using System.Security.Claims;
 
-namespace Controlmat.Application.Common.Commands.Washing;
+namespace Controlmat.Application.Common.Commands.WashCycle;
 
 public static class UploadPhotoCommand
 {


### PR DESCRIPTION
## Summary
- rename Washing commands to WashCycle and update namespaces
- adjust controller and program to use WashCycle commands

## Testing
- `dotnet build controlmat.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c5bafd098832da925e2ed3a7c23e0