### PR TITLE
refactor: rename washing commands namespace

### DIFF
--- a/SUMISAN AI Implementation Strategy.txt
+++ b/SUMISAN AI Implementation Strategy.txt
@@ -172,7 +172,7 @@ Implement wash business rules in CQRS handlers:
 ### **File Organization**
 ```
 Application/Common/
-├── Commands/Washing/
+├── Commands/WashCycle/
 │   ├── StartWashCommand.cs
 │   ├── FinishWashCommand.cs
 │   └── UploadPhotoCommand.cs

--- a/agent_AI/wash-management-agent-spec.txt
+++ b/agent_AI/wash-management-agent-spec.txt
@@ -87,10 +87,10 @@ controlmat/
 
 | Feature           | Component Type | Location                                                   |
 | ----------------- | -------------- | ---------------------------------------------------------- |
-| Start Wash        | Command        | `Application.Common.Commands.Washing.StartWashCommand`     |
-| Add Prot          | Command        | `Application.Common.Commands.Washing.AddProtCommand`       |
-| Upload Photo      | Command        | `Application.Common.Commands.Washing.UploadPhotoCommand`   |
-| Finish Wash       | Command        | `Application.Common.Commands.Washing.FinishWashCommand`    |
+| Start Wash        | Command        | `Application.Common.Commands.WashCycle.StartWashCommand`   |
+| Add Prot          | Command        | `Application.Common.Commands.WashCycle.AddProtCommand`     |
+| Upload Photo      | Command        | `Application.Common.Commands.WashCycle.UploadPhotoCommand` |
+| Finish Wash       | Command        | `Application.Common.Commands.WashCycle.FinishWashCommand`  |
 | Get Active Washes | Query          | `Application.Common.Queries.Washing.GetActiveWashesQuery`  |
 | Get by ID         | Query          | `Application.Common.Queries.Washing.GetWashByIdQuery`      |
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -73,7 +73,7 @@ backend/
 ### Phase 3: CQRS Implementation
 ```csharp
 // controlmat.Application/Common/
-├── Commands/Washing/
+├── Commands/WashCycle/
 │   ├── StartWashCommand.cs          # Begin new wash cycle
 │   ├── FinishWashCommand.cs         # Complete wash with validation
 │   ├── AddProtCommand.cs            # Add PROT to existing wash

--- a/backend/src/controlmat.Api/Controllers/WashingController.cs
+++ b/backend/src/controlmat.Api/Controllers/WashingController.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using MediatR;
-using Controlmat.Application.Common.Commands.Washing;
+using Controlmat.Application.Common.Commands.WashCycle;
 using Controlmat.Application.Common.Queries.Washing;
 using Controlmat.Application.Common.Queries.User;
 using Controlmat.Application.Common.Queries.Machine;

--- a/backend/src/controlmat.Api/Program.cs
+++ b/backend/src/controlmat.Api/Program.cs
@@ -26,7 +26,7 @@ builder.Services.AddAutoMapper(typeof(Controlmat.Application.Common.Mappings.Map
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddMediatR(cfg =>
 {
-    cfg.RegisterServicesFromAssembly(typeof(Controlmat.Application.Common.Commands.Washing.StartWashCommand).Assembly);
+    cfg.RegisterServicesFromAssembly(typeof(Controlmat.Application.Common.Commands.WashCycle.StartWashCommand).Assembly);
 });
 builder.Services.AddValidatorsFromAssemblyContaining<Controlmat.Application.Common.Validators.NewWashDtoValidator>();
 builder.Services.AddApplicationServices();

--- a/backend/src/controlmat.Application/Common/Commands/WashCycle/AddProtCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/WashCycle/AddProtCommand.cs
@@ -5,7 +5,7 @@ using Controlmat.Domain.Entities;
 using Controlmat.Domain.Interfaces;
 using System;
 
-namespace Controlmat.Application.Common.Commands.Washing;
+namespace Controlmat.Application.Common.Commands.WashCycle;
 
 public static class AddProtCommand
 {

--- a/backend/src/controlmat.Application/Common/Commands/WashCycle/FinishWashCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/WashCycle/FinishWashCommand.cs
@@ -5,7 +5,7 @@ using Controlmat.Application.Common.Dto;
 using Controlmat.Domain.Interfaces;
 using System;
 
-namespace Controlmat.Application.Common.Commands.Washing;
+namespace Controlmat.Application.Common.Commands.WashCycle;
 
 public static class FinishWashCommand
 {

--- a/backend/src/controlmat.Application/Common/Commands/WashCycle/StartWashCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/WashCycle/StartWashCommand.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System;
 using WashingEntity = Controlmat.Domain.Entities.Washing;
 
-namespace Controlmat.Application.Common.Commands.Washing;
+namespace Controlmat.Application.Common.Commands.WashCycle;
 
 public static class StartWashCommand
 {

--- a/backend/src/controlmat.Application/Common/Commands/WashCycle/UploadPhotoCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/WashCycle/UploadPhotoCommand.cs
@@ -6,7 +6,7 @@ using Controlmat.Domain.Interfaces;
 using Controlmat.Domain.Entities;
 using System.Security.Claims;
 
-namespace Controlmat.Application.Common.Commands.Washing;
+namespace Controlmat.Application.Common.Commands.WashCycle;
 
 public static class UploadPhotoCommand
 {


### PR DESCRIPTION
## Summary
- rename washing commands folder/namespace to WashCycle
- update controllers, program startup, and documentation references

## Testing
- `dotnet build controlmat.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c5dcca6c4832dac0df2b085cc443c