### PR TITLE
Remove duplicate DbSet definitions in ControlmatDbContext

### DIFF
--- a/backend/src/controlmat.Infrastructure/Persistence/ControlmatDbContext.cs
+++ b/backend/src/controlmat.Infrastructure/Persistence/ControlmatDbContext.cs
@@ -18,36 +18,13 @@ public class ControlmatDbContext : DbContext
     public DbSet<Photo> Photos => Set<Photo>();
     public DbSet<Parameter> Parameters => Set<Parameter>();
 
-
-    public DbSet<Parameter> Parameters => Set<Parameter>();
-
-    public DbSet<Machine> Machines => Set<Machine>();
-
-
-    public DbSet<Photo> Photos => Set<Photo>();
-
-    public DbSet<Prot> Prots => Set<Prot>();
-
-    public DbSet<Washing> Washings => Set<Washing>();
-
-
-
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-
-
         modelBuilder.ApplyConfiguration(new UserConfiguration());
-
         modelBuilder.ApplyConfiguration(new ParameterConfiguration());
-
-
         modelBuilder.ApplyConfiguration(new PhotoConfiguration());
-
-
         modelBuilder.ApplyConfiguration(new ProtConfiguration());
-
         modelBuilder.ApplyConfiguration(new WashingConfiguration());
-
     }
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate DbSet properties from `ControlmatDbContext`
- clean up `OnModelCreating` configuration calls

## Testing
- `dotnet build controlmat.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c7a838df4832d9949ff7bc32044a1