### PR TITLE
feat: expose active wash status via machines endpoint

### DIFF
--- a/backend/src/controlmat.Api/Controllers/MachinesController.cs
+++ b/backend/src/controlmat.Api/Controllers/MachinesController.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using MediatR;
+using Controlmat.Application.Common.Queries.Machine;
+
+namespace Controlmat.Api.Controllers;
+
+[ApiController]
+[Route("api/machines")]
+[Authorize(Roles = "WarehouseUser")]
+public class MachinesController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public MachinesController(IMediator mediator) => _mediator = mediator;
+
+    [HttpGet("active")]
+    public async Task<IActionResult> GetActiveWashes()
+        => Ok(await _mediator.Send(new GetActiveWashesQuery.Request()));
+}
+

--- a/backend/src/controlmat.Application/Common/Queries/Machine/GetActiveWashesQuery.cs
+++ b/backend/src/controlmat.Application/Common/Queries/Machine/GetActiveWashesQuery.cs
@@ -1,0 +1,42 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Controlmat.Application.Common.Dto;
+using Controlmat.Domain.Interfaces;
+using System.Linq;
+
+namespace Controlmat.Application.Common.Queries.Machine;
+
+public static class GetActiveWashesQuery
+{
+    public record Request : IRequest<List<ActiveWashDto>>;
+
+    public class Handler : IRequestHandler<Request, List<ActiveWashDto>>
+    {
+        private readonly IWashingRepository _repository;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(IWashingRepository repository, ILogger<Handler> logger)
+        {
+            _repository = repository;
+            _logger = logger;
+        }
+
+        public async Task<List<ActiveWashDto>> Handle(Request request, CancellationToken ct)
+        {
+            _logger.LogInformation("🌀 GetActiveWashesQuery - STARTED");
+
+            var activeWashes = await _repository.GetActiveWashesAsync();
+            var result = activeWashes.Select(w => new ActiveWashDto
+            {
+                MachineId = w.MachineId,
+                WashingId = w.WashingId,
+                StartDate = w.StartDate,
+                StartUserName = w.StartUser?.UserName ?? "Unknown"
+            }).ToList();
+
+            _logger.LogInformation("✅ GetActiveWashesQuery - COMPLETED. Found {Count} active washes", result.Count);
+            return result;
+        }
+    }
+}
+

--- a/backend/src/controlmat.Domain/Interfaces/IWashingRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IWashingRepository.cs
@@ -11,7 +11,7 @@ public interface IWashingRepository
 {
     Task<Washing?> GetByIdAsync(long id);
     Task<Washing?> GetByIdWithDetailsAsync(long id);
-    Task<IEnumerable<Washing>> GetActiveWashesAsync();
+    Task<List<Washing>> GetActiveWashesAsync();
     Task<int> CountActiveAsync();
     Task<bool> IsMachineInUseAsync(short machineId);
     Task<long?> GetMaxWashingIdByDateAsync(DateTime date);

--- a/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
@@ -34,10 +34,12 @@ namespace Controlmat.Infrastructure.Repositories
                 .FirstOrDefaultAsync(w => w.WashingId == id);
         }
 
-        public async Task<IEnumerable<Washing>> GetActiveWashesAsync()
+        public async Task<List<Washing>> GetActiveWashesAsync()
         {
             return await _context.Washings
-                .Where(w => w.Status != 'F')
+                .Where(w => w.Status == 'P')
+                .Include(w => w.StartUser)
+                .Include(w => w.Machine)
                 .ToListAsync();
         }
 


### PR DESCRIPTION
## Summary
- add MachinesController with `/api/machines/active` endpoint
- implement query handler to fetch active wash states
- expand washing repository to include active wash retrieval with machine and user

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689c7e62eee0832da699e55d35c812b4