### PR TITLE
feat: add photo download endpoint

### DIFF
--- a/backend/src/controlmat.Api/Controllers/PhotosController.cs
+++ b/backend/src/controlmat.Api/Controllers/PhotosController.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MediatR;
+using Controlmat.Application.Common.Queries.Photo;
+
+namespace Controlmat.Api.Controllers;
+
+[ApiController]
+[Route("api/photos")]
+[Authorize(Roles = "WarehouseUser")]
+public class PhotosController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public PhotosController(IMediator mediator) => _mediator = mediator;
+
+    [HttpGet("{photoId}/download")]
+    public async Task<IActionResult> DownloadPhoto(int photoId)
+    {
+        var result = await _mediator.Send(new DownloadPhotoQuery.Request(photoId));
+        if (result == null)
+            return NotFound();
+
+        return File(result.FileBytes, result.ContentType, result.FileName);
+    }
+}

--- a/backend/src/controlmat.Application/Common/Dto/PhotoDownloadDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/PhotoDownloadDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Controlmat.Application.Common.Dto;
+
+public class PhotoDownloadDto
+{
+    public byte[] FileBytes { get; set; } = Array.Empty<byte>();
+    public string ContentType { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+}

--- a/backend/src/controlmat.Application/Common/Queries/Photo/DownloadPhotoQuery.cs
+++ b/backend/src/controlmat.Application/Common/Queries/Photo/DownloadPhotoQuery.cs
@@ -1,0 +1,59 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Controlmat.Application.Common.Dto;
+using Controlmat.Domain.Interfaces;
+using System.IO;
+
+namespace Controlmat.Application.Common.Queries.Photo;
+
+public static class DownloadPhotoQuery
+{
+    public record Request(int PhotoId) : IRequest<PhotoDownloadDto?>;
+
+    public class Handler : IRequestHandler<Request, PhotoDownloadDto?>
+    {
+        private readonly IPhotoRepository _repository;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(IPhotoRepository repository, ILogger<Handler> logger)
+        {
+            _repository = repository;
+            _logger = logger;
+        }
+
+        public async Task<PhotoDownloadDto?> Handle(Request request, CancellationToken ct)
+        {
+            _logger.LogInformation("🌀 DownloadPhotoQuery - STARTED. PhotoId: {PhotoId}", request.PhotoId);
+
+            var photo = await _repository.GetByIdAsync(request.PhotoId);
+            if (photo == null)
+            {
+                _logger.LogWarning("⚠️ Photo not found: {PhotoId}", request.PhotoId);
+                return null;
+            }
+
+            if (!File.Exists(photo.FilePath))
+            {
+                _logger.LogError("❌ Photo file not found on disk: {FilePath}", photo.FilePath);
+                return null;
+            }
+
+            var fileBytes = await File.ReadAllBytesAsync(photo.FilePath, ct);
+            var contentType = Path.GetExtension(photo.FileName).ToLower() switch
+            {
+                ".jpg" or ".jpeg" => "image/jpeg",
+                ".png" => "image/png",
+                _ => "application/octet-stream"
+            };
+
+            _logger.LogInformation("✅ DownloadPhotoQuery - COMPLETED. File size: {Size} bytes", fileBytes.Length);
+
+            return new PhotoDownloadDto
+            {
+                FileBytes = fileBytes,
+                ContentType = contentType,
+                FileName = photo.FileName
+            };
+        }
+    }
+}

--- a/backend/src/controlmat.Domain/Interfaces/IPhotoRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IPhotoRepository.cs
@@ -7,6 +7,7 @@ namespace Controlmat.Domain.Interfaces;
 
 public interface IPhotoRepository
 {
+    Task<Photo?> GetByIdAsync(int photoId);
     Task<IEnumerable<Photo>> GetByWashingIdAsync(long washingId);
     Task<int> CountByWashingIdAsync(long washingId);
     Task AddAsync(Photo photo);

--- a/backend/src/controlmat.Infrastructure/Repositories/PhotoRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/PhotoRepository.cs
@@ -17,6 +17,11 @@ namespace Controlmat.Infrastructure.Repositories
             _context = context;
         }
 
+        public async Task<Photo?> GetByIdAsync(int photoId)
+        {
+            return await _context.Photos.FirstOrDefaultAsync(p => p.Id == photoId);
+        }
+
         public async Task<IEnumerable<Photo>> GetByWashingIdAsync(long washingId)
         {
             return await _context.Photos


### PR DESCRIPTION
## Summary
- add PhotosController with secure download endpoint
- implement DownloadPhotoQuery with disk streaming logic
- extend photo repository and DTOs for file responses

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c7e7adde4832d89317d89600c9f14