### PR TITLE
feat: add wash photo listing endpoint

### DIFF
--- a/backend/src/controlmat.Api/Controllers/WashingController.cs
+++ b/backend/src/controlmat.Api/Controllers/WashingController.cs
@@ -167,6 +167,17 @@ namespace Controlmat.Api.Controllers
         }
 
         /// <summary>
+        /// Get photos for a wash
+        /// </summary>
+        /// <param name="washId">Washing ID</param>
+        /// <returns>List of photos with metadata</returns>
+        /// <response code="200">Photos retrieved successfully</response>
+        [HttpGet("{washId}/photos")]
+        [ProducesResponseType(typeof(List<PhotoDto>), 200)]
+        public async Task<IActionResult> GetWashPhotos(long washId)
+            => Ok(await _mediator.Send(new GetWashPhotosQuery.Request(washId)));
+
+        /// <summary>
         /// Add a PROT (instrument kit) to an active wash
         /// </summary>
         /// <param name="id">Washing ID</param>

--- a/backend/src/controlmat.Application/Common/Dto/PhotoDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/PhotoDto.cs
@@ -8,6 +8,6 @@ public class PhotoDto
 {
     public int Id { get; set; }
     public string FileName { get; set; } = string.Empty;
-    public string FilePath { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
+    public string DownloadUrl { get; set; } = string.Empty;
 }

--- a/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
+++ b/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
@@ -27,7 +27,8 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.WashingId, opt => opt.Ignore())
             .ForMember(dest => dest.Washing, opt => opt.Ignore());
 
-        CreateMap<Photo, PhotoDto>();
+        CreateMap<Photo, PhotoDto>()
+            .ForMember(dest => dest.DownloadUrl, opt => opt.MapFrom(src => $"/api/photos/{src.Id}/download"));
         CreateMap<User, UserDto>();
 
         CreateMap<Machine, MachineDto>()

--- a/backend/src/controlmat.Application/Common/Queries/Washing/GetWashPhotosQuery.cs
+++ b/backend/src/controlmat.Application/Common/Queries/Washing/GetWashPhotosQuery.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Controlmat.Application.Common.Dto;
+using Controlmat.Domain.Interfaces;
+
+namespace Controlmat.Application.Common.Queries.Washing;
+
+public static class GetWashPhotosQuery
+{
+    public record Request(long WashId) : IRequest<List<PhotoDto>>;
+
+    public class Handler : IRequestHandler<Request, List<PhotoDto>>
+    {
+        private readonly IPhotoRepository _repository;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(IPhotoRepository repository, ILogger<Handler> logger)
+        {
+            _repository = repository;
+            _logger = logger;
+        }
+
+        public async Task<List<PhotoDto>> Handle(Request request, CancellationToken ct)
+        {
+            _logger.LogInformation("🌀 GetWashPhotosQuery - STARTED. WashId: {WashId}", request.WashId);
+
+            var photos = await _repository.GetByWashIdAsync(request.WashId);
+            var result = photos.Select(p => new PhotoDto
+            {
+                Id = p.Id,
+                FileName = p.FileName,
+                CreatedAt = p.CreatedAt,
+                DownloadUrl = $"/api/photos/{p.Id}/download"
+            }).ToList();
+
+            _logger.LogInformation("✅ GetWashPhotosQuery - COMPLETED. Found {Count} photos", result.Count);
+            return result;
+        }
+    }
+}

--- a/backend/src/controlmat.Domain/Interfaces/IPhotoRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IPhotoRepository.cs
@@ -7,7 +7,7 @@ namespace Controlmat.Domain.Interfaces;
 
 public interface IPhotoRepository
 {
-    Task<IEnumerable<Photo>> GetByWashingIdAsync(long washingId);
+    Task<List<Photo>> GetByWashIdAsync(long washingId);
     Task<int> CountByWashingIdAsync(long washingId);
     Task AddAsync(Photo photo);
 }

--- a/backend/src/controlmat.Infrastructure/Repositories/PhotoRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/PhotoRepository.cs
@@ -17,10 +17,11 @@ namespace Controlmat.Infrastructure.Repositories
             _context = context;
         }
 
-        public async Task<IEnumerable<Photo>> GetByWashingIdAsync(long washingId)
+        public async Task<List<Photo>> GetByWashIdAsync(long washingId)
         {
             return await _context.Photos
                 .Where(p => p.WashingId == washingId)
+                .OrderBy(p => p.CreatedAt)
                 .ToListAsync();
         }
 


### PR DESCRIPTION
## Summary
- add API endpoint to list wash photos with metadata
- map photo download URLs and update DTOs
- implement repository method and query for wash photos

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c8229c138832d9056ebdc0b4304dc