### PR TITLE
feat: expose active machine wash status

### DIFF
--- a/backend/src/controlmat.Application/Common/Dto/ActiveWashDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/ActiveWashDto.cs
@@ -6,12 +6,9 @@ namespace Controlmat.Application.Common.Dto;
 
 public class ActiveWashDto
 {
+    public int MachineId { get; set; }
     public long WashingId { get; set; }
-    public short MachineId { get; set; }
-    public string MachineName { get; set; } = string.Empty;
     public DateTime StartDate { get; set; }
     public string StartUserName { get; set; } = string.Empty;
-    public int ProtCount { get; set; }
-    public int PhotoCount { get; set; }
 
 }

--- a/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
+++ b/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
@@ -16,10 +16,7 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.StatusDescription, opt => opt.MapFrom(src => src.Status == 'P' ? "En Progreso" : "Finalizado"));
 
         CreateMap<Washing, ActiveWashDto>()
-            .ForMember(dest => dest.MachineName, opt => opt.MapFrom(src => src.Machine.Name))
-            .ForMember(dest => dest.StartUserName, opt => opt.MapFrom(src => src.StartUser.UserName))
-            .ForMember(dest => dest.ProtCount, opt => opt.MapFrom(src => src.Prots.Count))
-            .ForMember(dest => dest.PhotoCount, opt => opt.MapFrom(src => src.Photos.Count));
+            .ForMember(dest => dest.StartUserName, opt => opt.MapFrom(src => src.StartUser.UserName));
 
         CreateMap<Prot, ProtDto>();
         CreateMap<ProtDto, Prot>()


### PR DESCRIPTION
## Summary
- add controller for machines active washes
- implement query to list active washes per machine
- simplify ActiveWashDto and update mapping

## Testing
- ⚠️ `dotnet test` *(command not found)*
- ⚠️ `sudo apt-get update` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c8d5d7010832d89c070f05e60a4c0