### PR TITLE
feat: add wash lookup by machine

### DIFF
--- a/backend/src/controlmat.Api/Controllers/WashingController.cs
+++ b/backend/src/controlmat.Api/Controllers/WashingController.cs
@@ -165,6 +165,15 @@ namespace Controlmat.Api.Controllers
         }
 
 
+        /// <summary>
+        /// Get the active wash for a specific machine
+        /// </summary>
+        /// <param name="machineId">Machine ID</param>
+        /// <returns>Active wash details including PROTs and photos</returns>
+        [HttpGet("by-machine/{machineId}")]
+        public async Task<IActionResult> GetByMachine(int machineId)
+            => Ok(await _mediator.Send(new GetWashByMachineQuery.Request(machineId)));
+
         /// Get detailed wash information by ID
         /// </summary>
         /// <param name="id">Washing ID</param>

--- a/backend/src/controlmat.Domain/Interfaces/IWashingRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IWashingRepository.cs
@@ -13,6 +13,7 @@ public interface IWashingRepository
     Task<Washing?> GetByIdWithDetailsAsync(long id);
 
     Task<List<Washing>> GetActiveWashesAsync();
+    Task<Washing?> GetActiveWashByMachineAsync(int machineId);
     Task<int> CountActiveAsync();
     Task<bool> IsMachineInUseAsync(short machineId);
     Task<long?> GetMaxWashingIdByDateAsync(DateTime date);


### PR DESCRIPTION
## Summary
- expose active wash retrieval for a machine via GET /api/washing/by-machine/{machineId}
- add repository contract for querying active wash by machine

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c8d650054832db57dbfd433bd14fd