### PR TITLE
feat: add bulk wash photo download endpoint

### DIFF
--- a/backend/src/controlmat.Api/Controllers/WashingController.cs
+++ b/backend/src/controlmat.Api/Controllers/WashingController.cs
@@ -164,6 +164,23 @@ namespace Controlmat.Api.Controllers
             }
         }
 
+        /// <summary>
+        /// Download all photos for a wash as a ZIP archive
+        /// </summary>
+        /// <param name="washId">Washing ID</param>
+        /// <returns>ZIP file containing all photos</returns>
+        /// <response code="200">ZIP file generated successfully</response>
+        /// <response code="404">No photos found for this wash</response>
+        [HttpGet("{washId}/photos/download")]
+        public async Task<IActionResult> DownloadWashPhotos(long washId)
+        {
+            var result = await _mediator.Send(new DownloadWashPhotosQuery.Request(washId));
+            if (result == null)
+                return NotFound("No photos found for this wash");
+
+            return File(result.ZipBytes, "application/zip", $"wash_{washId}_photos.zip");
+        }
+
 
         /// Get detailed wash information by ID
         /// </summary>

--- a/backend/src/controlmat.Application/Common/Dto/WashPhotosZipDto.cs
+++ b/backend/src/controlmat.Application/Common/Dto/WashPhotosZipDto.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Controlmat.Application.Common.Dto;
+
+public class WashPhotosZipDto
+{
+    public byte[] ZipBytes { get; set; } = Array.Empty<byte>();
+}
+

--- a/backend/src/controlmat.Application/Common/Queries/Washing/DownloadWashPhotosQuery.cs
+++ b/backend/src/controlmat.Application/Common/Queries/Washing/DownloadWashPhotosQuery.cs
@@ -1,0 +1,64 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Controlmat.Application.Common.Dto;
+using Controlmat.Domain.Interfaces;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace Controlmat.Application.Common.Queries.Washing;
+
+public static class DownloadWashPhotosQuery
+{
+    public record Request(long WashId) : IRequest<WashPhotosZipDto?>;
+
+    public class Handler : IRequestHandler<Request, WashPhotosZipDto?>
+    {
+        private readonly IPhotoRepository _repository;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(IPhotoRepository repository, ILogger<Handler> logger)
+        {
+            _repository = repository;
+            _logger = logger;
+        }
+
+        public async Task<WashPhotosZipDto?> Handle(Request request, CancellationToken ct)
+        {
+            _logger.LogInformation("🌀 DownloadWashPhotosQuery - STARTED. WashId: {WashId}", request.WashId);
+
+            var photos = (await _repository.GetByWashingIdAsync(request.WashId)).ToList();
+            if (!photos.Any())
+            {
+                _logger.LogWarning("⚠️ No photos found for wash: {WashId}", request.WashId);
+                return null;
+            }
+
+            using var memoryStream = new MemoryStream();
+            using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
+            {
+                foreach (var photo in photos)
+                {
+                    if (File.Exists(photo.FilePath))
+                    {
+                        var entry = archive.CreateEntry(photo.FileName);
+                        using var entryStream = entry.Open();
+                        using var fileStream = File.OpenRead(photo.FilePath);
+                        await fileStream.CopyToAsync(entryStream, ct);
+                    }
+                    else
+                    {
+                        _logger.LogWarning("⚠️ Photo file not found: {FilePath}", photo.FilePath);
+                    }
+                }
+            }
+
+            var zipBytes = memoryStream.ToArray();
+            _logger.LogInformation("✅ DownloadWashPhotosQuery - COMPLETED. ZIP size: {Size} bytes, Photos: {Count}",
+                zipBytes.Length, photos.Count);
+
+            return new WashPhotosZipDto { ZipBytes = zipBytes };
+        }
+    }
+}
+

--- a/backend/src/controlmat.Application/controlmat.Application.csproj
+++ b/backend/src/controlmat.Application/controlmat.Application.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- allow downloading all wash photos in a single zip
- query handler zips existing photo files and logs missing ones
- add DTO and compression package reference

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c8d81267c832d8863b54ee7acac49