### PR TITLE
Secure washing endpoints and extend AutoMapper mappings

### DIFF
--- a/backend/src/controlmat.Api/Controllers/WashingController.cs
+++ b/backend/src/controlmat.Api/Controllers/WashingController.cs
@@ -13,7 +13,7 @@ namespace Controlmat.Api.Controllers
     /// </summary>
     [ApiController]
     [Route("api/washing")]
-    [AllowAnonymous]
+    [Authorize(Roles = "WarehouseUser")]
     [Produces("application/json")]
     [Tags("Washing")]
     public class WashingController : ControllerBase

--- a/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
+++ b/backend/src/controlmat.Application/Common/Mappings/MappingProfile.cs
@@ -26,10 +26,16 @@ public class MappingProfile : Profile
 
         CreateMap<Photo, PhotoDto>()
             .ForMember(dest => dest.DownloadUrl, opt => opt.MapFrom(src => $"/api/photos/{src.Id}/download"));
+        CreateMap<Photo, PhotoDownloadDto>()
+            .ForMember(dest => dest.FileBytes, opt => opt.Ignore())
+            .ForMember(dest => dest.ContentType, opt => opt.Ignore());
         CreateMap<User, UserDto>();
 
         CreateMap<Machine, MachineDto>()
             .ForMember(dest => dest.IsAvailable, opt => opt.Ignore());
+
+        CreateMap<Washing, WashPhotosZipDto>()
+            .ForMember(dest => dest.ZipBytes, opt => opt.Ignore());
 
     }
 }


### PR DESCRIPTION
## Summary
- Require `WarehouseUser` role across washing endpoints
- Map photos and wash downloads in `MappingProfile`

## Testing
- ⚠️ `dotnet clean controlmat.sln` *(missing .NET SDK in container)*
- ⚠️ `dotnet build controlmat.sln` *(missing .NET SDK in container)*

------
https://chatgpt.com/codex/tasks/task_e_689c90b9c434832dbe15291739ce091d