### PR TITLE
feat: add washing id prefix lookup

### DIFF
--- a/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
@@ -84,5 +84,28 @@ namespace Controlmat.Infrastructure.Repositories
             _context.Washings.Update(washing);
             await _context.SaveChangesAsync();
         }
+
+        /// <summary>
+        /// Gets all WashingIds that start with the given date prefix (YYMMDD)
+        /// Used for generating sequential WashingIds within a day
+        /// </summary>
+        public async Task<IEnumerable<long>> GetWashingIdsByDatePrefixAsync(string datePrefix)
+        {
+            if (string.IsNullOrEmpty(datePrefix) || datePrefix.Length != 6)
+            {
+                throw new ArgumentException("Date prefix must be 6 characters in YYMMDD format", nameof(datePrefix));
+            }
+
+            // Parse the date prefix to get the range
+            var prefixAsLong = long.Parse(datePrefix) * 100; // e.g., 250813 -> 25081300
+            var rangeStart = prefixAsLong;                    // 25081300
+            var rangeEnd = prefixAsLong + 99;                 // 25081399
+
+            return await _context.Washings
+                .Where(w => w.WashingId >= rangeStart && w.WashingId <= rangeEnd)
+                .Select(w => w.WashingId)
+                .OrderBy(id => id)
+                .ToListAsync();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement GetWashingIdsByDatePrefixAsync in WashingRepository for sequential daily IDs

## Testing
- `dotnet build backend/controlmat.sln` *(fails: command not found: dotnet)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_689cba07487c832daf3cb43a11c39497