### PR TITLE
Generate sequential washing ids

### DIFF
--- a/backend/src/controlmat.Domain/Interfaces/IWashingRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IWashingRepository.cs
@@ -17,6 +17,7 @@ public interface IWashingRepository
     Task<int> CountActiveAsync();
     Task<bool> IsMachineInUseAsync(short machineId);
     Task<long?> GetMaxWashingIdByDateAsync(DateTime date);
+    Task<List<long>> GetWashingIdsByDatePrefixAsync(string datePrefix);
     Task AddAsync(Washing washing);
     Task UpdateAsync(Washing washing);
 

--- a/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/WashingRepository.cs
@@ -73,6 +73,17 @@ namespace Controlmat.Infrastructure.Repositories
                 .MaxAsync();
         }
 
+        public async Task<List<long>> GetWashingIdsByDatePrefixAsync(string datePrefix)
+        {
+            var start = long.Parse(datePrefix) * 100;
+            var end = start + 99;
+
+            return await _context.Washings
+                .Where(w => w.WashingId >= start && w.WashingId <= end)
+                .Select(w => w.WashingId)
+                .ToListAsync();
+        }
+
         public async Task AddAsync(Washing washing)
         {
             await _context.Washings.AddAsync(washing);


### PR DESCRIPTION
## Summary
- generate YYMMDD-based washing id with daily sequence
- expose repository method to fetch washing ids by date prefix

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cba0eccb4832d9f727c05832ef69f