### PR TITLE
Validate machine ID in wash query

### DIFF
--- a/backend/src/controlmat.Domain/Interfaces/IMachineRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IMachineRepository.cs
@@ -9,5 +9,6 @@ public interface IMachineRepository
 {
     Task<Machine?> GetByIdAsync(short machineId);
     Task<IEnumerable<Machine>> GetAllAsync();
+    Task<bool> ExistsAsync(int machineId);
 
 }

--- a/backend/src/controlmat.Infrastructure/Repositories/MachineRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/MachineRepository.cs
@@ -25,5 +25,10 @@ namespace Controlmat.Infrastructure.Repositories
         {
             return await _context.Machines.ToListAsync();
         }
+
+        public async Task<bool> ExistsAsync(int machineId)
+        {
+            return await _context.Machines.AnyAsync(m => m.Id == machineId);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add machine ID range and existence checks to GetWashByMachineQuery handler
- expose IMachineRepository.ExistsAsync and implement in repository

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689da2a16138832da3b265dec5a24225