### PR TITLE
feat: implement AddProt command validations

### DIFF
--- a/backend/src/controlmat.Application/Common/Commands/WashCycle/AddProtCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/WashCycle/AddProtCommand.cs
@@ -1,0 +1,91 @@
+using AutoMapper;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Controlmat.Application.Common.Constants;
+using Controlmat.Application.Common.Dto;
+using Controlmat.Domain.Entities;
+using Controlmat.Domain.Interfaces;
+
+namespace Controlmat.Application.Common.Commands.WashCycle;
+
+public static class AddProtCommand
+{
+    public class Request : IRequest<ProtDto>
+    {
+        public long WashingId { get; set; }
+        public ProtDto Dto { get; set; } = default!;
+    }
+
+    public class Handler : IRequestHandler<Request, ProtDto>
+    {
+        private readonly IWashingRepository _washingRepo;
+        private readonly IProtRepository _protRepo;
+        private readonly IMapper _mapper;
+        private readonly ILogger<Handler> _logger;
+
+        public Handler(IWashingRepository washingRepo, IProtRepository protRepo, IMapper mapper, ILogger<Handler> logger)
+        {
+            _washingRepo = washingRepo;
+            _protRepo = protRepo;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        public async Task<ProtDto> Handle(Request request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var washingId = request.WashingId;
+                var dto = request.Dto;
+
+                _logger.LogInformation("Adding PROT {ProtId} to wash {WashingId}", dto.ProtId, washingId);
+
+                if (!IsValidWashingId(washingId))
+                    throw new ArgumentException(ValidationErrorMessages.Washing.InvalidIdFormat(washingId));
+
+                var washing = await _washingRepo.GetByIdAsync(washingId);
+                if (washing == null)
+                    throw new InvalidOperationException(ValidationErrorMessages.Washing.NotFound(washingId));
+
+                if (washing.Status != 'P')
+                    throw new InvalidOperationException(ValidationErrorMessages.Washing.AlreadyFinished(washingId));
+
+                if (!Regex.IsMatch(dto.ProtId, @"^PROT[0-9]{3}$"))
+                    throw new ArgumentException(ValidationErrorMessages.Prot.InvalidProtIdFormat(dto.ProtId));
+
+                if (!Regex.IsMatch(dto.BatchNumber, @"^NL[0-9]{2}$"))
+                    throw new ArgumentException(ValidationErrorMessages.Prot.InvalidBatchNumberFormat(dto.BatchNumber));
+
+                if (!Regex.IsMatch(dto.BagNumber, @"^[0-9]{2}/[0-9]{2}$"))
+                    throw new ArgumentException(ValidationErrorMessages.Prot.InvalidBagNumberFormat(dto.BagNumber));
+
+                if (await _protRepo.ExistsInWashAsync(washingId, dto.ProtId, dto.BatchNumber, dto.BagNumber))
+                    throw new InvalidOperationException(ValidationErrorMessages.Prot.DuplicateProtInWash(dto.ProtId, dto.BatchNumber, dto.BagNumber));
+
+                var prot = _mapper.Map<Prot>(dto);
+                prot.WashingId = washingId;
+
+                await _protRepo.AddAsync(prot);
+
+                return _mapper.Map<ProtDto>(prot);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error adding PROT to wash {WashingId}", request.WashingId);
+                throw;
+            }
+        }
+
+        private static bool IsValidWashingId(long washingId)
+        {
+            var idStr = washingId.ToString();
+            if (!Regex.IsMatch(idStr, @"^\d{8}$"))
+                return false;
+            return DateTime.TryParseExact(idStr.Substring(0, 6), "yyMMdd", null, System.Globalization.DateTimeStyles.None, out _);
+        }
+    }
+}

--- a/backend/src/controlmat.Domain/Interfaces/IProtRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IProtRepository.cs
@@ -8,4 +8,5 @@ public interface IProtRepository
 {
     Task<IEnumerable<Prot>> GetByWashingIdAsync(long washingId);
     Task AddAsync(Prot prot);
+    Task<bool> ExistsInWashAsync(long washingId, string protId, string batchNumber, string bagNumber);
 }

--- a/backend/src/controlmat.Infrastructure/Repositories/ProtRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/ProtRepository.cs
@@ -29,5 +29,14 @@ namespace Controlmat.Infrastructure.Repositories
             await _context.Prots.AddAsync(prot);
             await _context.SaveChangesAsync();
         }
+
+        public async Task<bool> ExistsInWashAsync(long washingId, string protId, string batchNumber, string bagNumber)
+        {
+            return await _context.Prots.AnyAsync(p =>
+                p.WashingId == washingId &&
+                p.ProtId == protId &&
+                p.BatchNumber == batchNumber &&
+                p.BagNumber == bagNumber);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add ExistsInWashAsync to Prot repository interface and implementation
- introduce AddProtCommand with washing and PROT validation logic

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689da28dea30832d9e872f97de36a696