### PR TITLE
Add validations for FinishWashCommand

### DIFF
--- a/backend/src/controlmat.Application/Common/Commands/WashCycle/FinishWashCommand.cs
+++ b/backend/src/controlmat.Application/Common/Commands/WashCycle/FinishWashCommand.cs
@@ -1,9 +1,11 @@
 using AutoMapper;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using Controlmat.Application.Common.Constants;
 using Controlmat.Application.Common.Dto;
 using Controlmat.Domain.Interfaces;
 using System;
+using System.Text.RegularExpressions;
 
 namespace Controlmat.Application.Common.Commands.WashCycle;
 
@@ -18,12 +20,21 @@ public static class FinishWashCommand
     public class Handler : IRequestHandler<Request, WashingResponseDto>
     {
         private readonly IWashingRepository _washingRepo;
+        private readonly IUserRepository _userRepo;
+        private readonly IPhotoRepository _photoRepo;
         private readonly IMapper _mapper;
         private readonly ILogger<Handler> _logger;
 
-        public Handler(IWashingRepository washingRepo, IMapper mapper, ILogger<Handler> logger)
+        public Handler(
+            IWashingRepository washingRepo,
+            IUserRepository userRepo,
+            IPhotoRepository photoRepo,
+            IMapper mapper,
+            ILogger<Handler> logger)
         {
             _washingRepo = washingRepo;
+            _userRepo = userRepo;
+            _photoRepo = photoRepo;
             _mapper = mapper;
             _logger = logger;
         }
@@ -32,16 +43,31 @@ public static class FinishWashCommand
         {
             try
             {
-                _logger.LogInformation("Finishing wash {WashingId} by user {EndUserId}", request.WashingId, request.Dto.EndUserId);
+                var washingId = request.WashingId;
+                var dto = request.Dto;
 
-                var washing = await _washingRepo.GetByIdAsync(request.WashingId)
-                    ?? throw new InvalidOperationException($"Washing with ID {request.WashingId} not found");
+                _logger.LogInformation("Finishing wash {WashingId} by user {EndUserId}", washingId, dto.EndUserId);
 
-                if (washing.Status == 'F')
-                    throw new InvalidOperationException($"Washing {request.WashingId} already finished");
+                if (!IsValidWashingId(washingId))
+                    throw new ArgumentException(ValidationErrorMessages.Washing.InvalidIdFormat(washingId));
 
-                washing.EndUserId = request.Dto.EndUserId;
-                washing.FinishObservation = request.Dto.FinishObservation;
+                var washing = await _washingRepo.GetByIdAsync(washingId)
+                    ?? throw new InvalidOperationException(ValidationErrorMessages.Washing.NotFound(washingId));
+
+                if (!await _userRepo.ExistsAsync(dto.EndUserId))
+                    throw new InvalidOperationException(ValidationErrorMessages.User.EndUserNotFound(dto.EndUserId));
+
+                if (washing.Status != 'P')
+                    throw new InvalidOperationException(ValidationErrorMessages.Washing.NotInProgress(washingId));
+
+                if (await _photoRepo.CountByWashingIdAsync(washingId) < 1)
+                    throw new InvalidOperationException(ValidationErrorMessages.Washing.MustHavePhotosToFinish(washingId));
+
+                if (!string.IsNullOrEmpty(dto.FinishObservation) && dto.FinishObservation.Length > 100)
+                    throw new ArgumentException(ValidationErrorMessages.Observation.FinishObservationTooLong(100));
+
+                washing.EndUserId = dto.EndUserId;
+                washing.FinishObservation = dto.FinishObservation;
                 washing.EndDate = DateTime.UtcNow;
                 washing.Status = 'F';
 
@@ -56,6 +82,14 @@ public static class FinishWashCommand
                 _logger.LogError(ex, "Error finishing wash {WashingId}", request.WashingId);
                 throw;
             }
+        }
+
+        private static bool IsValidWashingId(long washingId)
+        {
+            var idStr = washingId.ToString();
+            if (!Regex.IsMatch(idStr, @"^\d{8}$"))
+                return false;
+            return DateTime.TryParseExact(idStr.Substring(0, 6), "yyMMdd", null, System.Globalization.DateTimeStyles.None, out _);
         }
     }
 }

--- a/backend/src/controlmat.Domain/Interfaces/IUserRepository.cs
+++ b/backend/src/controlmat.Domain/Interfaces/IUserRepository.cs
@@ -9,5 +9,6 @@ public interface IUserRepository
 {
     Task<User?> GetByIdAsync(int userId);
     Task<IEnumerable<User>> GetAllAsync();
+    Task<bool> ExistsAsync(int userId);
 
 }

--- a/backend/src/controlmat.Infrastructure/Repositories/UserRepository.cs
+++ b/backend/src/controlmat.Infrastructure/Repositories/UserRepository.cs
@@ -25,5 +25,10 @@ namespace Controlmat.Infrastructure.Repositories
         {
             return await _context.Users.ToListAsync();
         }
+
+        public async Task<bool> ExistsAsync(int userId)
+        {
+            return await _context.Users.AnyAsync(u => u.Id == userId);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- validate wash ID format, status, photo count, end-user existence, and observation length in FinishWashCommand handler
- add ExistsAsync to IUserRepository for end-user lookup

## Testing
- `dotnet build backend/controlmat.sln -c Release` *(fails: command not found)*
- `apt-get update` *(403 forbidden: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689db14354b0832da8766f2889e7d2ce