### PR TITLE
Validate washing ID and handle missing washes

### DIFF
--- a/backend/src/controlmat.Application/Common/Exceptions/NotFoundException.cs
+++ b/backend/src/controlmat.Application/Common/Exceptions/NotFoundException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Controlmat.Application.Common.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when a requested entity is not found.
+    /// </summary>
+    public class NotFoundException : Exception
+    {
+        public NotFoundException() { }
+
+        public NotFoundException(string message) : base(message) { }
+
+        public NotFoundException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add NotFoundException for missing entities
- validate washing ID format and throw NotFoundException when not found
- handle validation and not-found errors in washing controller

## Testing
- `dotnet build controlmat.Api` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689db1cbea9c832d9745f31a263d7fad