### PR TITLE
Add validation for wash retrieval by ID

### DIFF
--- a/backend/src/controlmat.Application/Common/Exceptions/NotFoundException.cs
+++ b/backend/src/controlmat.Application/Common/Exceptions/NotFoundException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Controlmat.Application.Common.Exceptions
+{
+    public class NotFoundException : Exception
+    {
+        public NotFoundException(string message) : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate washing ID format and existence in GetWashByIdQuery
- add custom NotFoundException for missing resources

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689dc3299828832d893dcb092eed1e6b